### PR TITLE
Fix canonical address resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "crypto_common",
  "derive_more",
  "ecvrf",
+ "ed25519",
  "ed25519-dalek",
  "eddsa_ed25519",
  "encrypted_transfers",
@@ -2320,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-logger"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-logger"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,7 +401,7 @@ async fn use_node(
                         for address in affected_addresses.into_iter() {
                             if let Some(addr) = canonical_cache.get(address.as_ref()) {
                                 let addr = AccountAddress::from(*addr);
-                                if !seen.insert(addr) {
+                                if seen.insert(addr) {
                                     addresses.push(addr);
                                 }
                             } else {
@@ -410,7 +410,7 @@ async fn use_node(
                                     .await
                                     .context("Error querying account info.")?;
                                 let addr = ainfo.account_address();
-                                if !seen.insert(addr) {
+                                if seen.insert(addr) {
                                     log::debug!("Discovered new address {}", addr);
                                     addresses.push(addr);
                                     canonical_cache.insert(AccountAddressEq(addr));


### PR DESCRIPTION
## Purpose

Fix handling of canonical accounts.

## Changes

Make the logic include the account the first time it's seen instead of negating that check.

Tested on [this](https://support.concordium.software/t/transaction-logger-misses-left-transactions-and-leads-to-differences-with-the-traditional-logger/397?u=sderuiter) reported example.

After applying this chacnge, the ATI query returns the correct result:

```
# select * from ati where summary=753;
  id  |                              account                               | summary 
------+--------------------------------------------------------------------+---------
 2833 | \x184e2b4de708738c06c8f618dce895e9e73ea67b6dc6efdbd30eb65a00570f31 |     753
 2834 | \x8e024c4e285583f06a8d68574ed822c004444f2c04c9eabce2be24f6ca051f36 |     753
(2 rows)
```

The accounts are indeed the hex encodings of the ones involved in summary 753:

```
# select * from summaries where id=753;
 id  |                               block                                |   timestamp   | height |                                                                                                                                                                                                                                                                                   summary                                                                                                                                                                                                                                                                                   
-----+--------------------------------------------------------------------+---------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 753 | \x2a178cc63f8cf19683dff8297c9ae8c7de93c99c8809c8de1531f3daf043333a | 1623220987500 |    261 | {"Left": {"cost": "6010", "hash": "b010562ed14cde371f48fdc39526f312395950b83cd7c42c864b1b5e38d58e87", "type": {"type": "accountTransaction", "contents": "transfer"}, "index": 0, "result": {"events": [{"to": {"type": "AddressAccount", "address": "42Hc6eq8GaKpz7w9B7tGD1mNWLjbYFq3iSyK5NjNPNif7fgNVS"}, "tag": "Transferred", "from": {"type": "AddressAccount", "address": "38T2PSXK6JVqNmoGqzjtnYsyb76uuNYKSpEoA8vPdtmRmpZhAv"}, "amount": "3000000000"}], "outcome": "success"}, "sender": "38T2PSXK6JVqNmoGqzjtnYsyb76uuNYKSpEoA8vPdtmRmpZhAv", "energyCost": 601}}
(1 row)
```