### PR TITLE
Fix parsing of key updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.3.1
+
+- Fix parsing of level1 and root key updates in block summaries.
+
 ## 0.3.0
 - Support for node version 4 API.
 - Support delegation and new contract events.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "aggregate_sig",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-logger"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Purpose

The Rust SDK did not support the new V1 variants so it failed parsing some block summaries.

## Changes

The fix is in the SDK parsing.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.