### PR TITLE
Migrate the transaction logger to V2 GRPC API.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch: # allows manual trigger
 
 env:
-  RUST_FMT: nightly-2021-06-09-x86_64-unknown-linux-gnu
-  RUST_CLIPPY: 1.57
+  RUST_FMT: nightly-2022-06-09-x86_64-unknown-linux-gnu
+  RUST_CLIPPY: 1.61
 
 jobs:
   "lint_fmt":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.5.0
+
+- Use Rust SDK V2.
+- The logger now requires the V2 GRPC API.
+- Minimum Rust version is bumped to 1.61
+- `TRANSACTION_LOGGER_RPC_TOKEN` is no longer supported
+
 ## 0.4.0
 
 - Bump Node SDK.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-logger"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-logger"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 ARG build_image
 ARG base_image
 FROM ${build_image} AS build
-# Install system dependencies ('cmake' is a dependency of Rust crate 'prost-build').
-RUN apt update && apt install -y cmake && rm -rf /var/lib/apt/lists/*
+# Install protoc
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip
+RUN unzip protoc-3.15.3-linux-x86_64.zip
+RUN mv ./bin/protoc /usr/bin/protoc
+
 WORKDIR /build
 COPY . .
 RUN cargo build --release

--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ Log affected accounts and smart contracts into a postgres database.
 - `TRANSACTION_LOGGER_NODES`
   List of nodes to query. They are used in order, and the next one is only used
   if querying preceding one failed. Must be non-empty. For example
-  `http://localhost:10000,http://localhost:13000`
-
-- `TRANSACTION_LOGGER_RPC_TOKEN`
-  GRPC access token for all the nodes.
+  `http://localhost:20000,http://localhost:23000`
 
 - `TRANSACTION_LOGGER_DB_STRING`
   Database connection string for the postgres database.
@@ -167,16 +164,16 @@ Changes to any of the packages must be such that
 - ```cargo clippy --all``` produces no warnings
 - ```rust fmt``` makes no changes.
 
-Everything in this repository should build with stable rust at the moment (at least version 1.56 and up), however the fmt tool must be from a nightly release since some of the configuration options are not stable. One way to run the `fmt` tool is
+Everything in this repository should build with stable rust at the moment (at least version 1.60 and up), however the fmt tool must be from a nightly release since some of the configuration options are not stable. One way to run the `fmt` tool is
 
 ```shell
- cargo +nightly-2021-06-09 fmt
+ cargo +nightly-2022-06-09 fmt
 ```
 (the exact version used by the CI can be found in [.github/workflows/ci.yaml](.github/workflows/ci.yaml) file).
 You will need to have a recent enough nightly version installed, which can be done via
 
 ```shell
-rustup toolchain install nightly-2021-06-09
+rustup toolchain install nightly-2022-06-09
 ```
 or similar, using the [rustup](https://rustup.rs/) tool. See the documentation of the tool for more details.
 
@@ -205,6 +202,6 @@ with the service installed and set as the entrypoint.
 
 This docker image can be built using
 ```
-docker build --build-arg build_image=rust:1.56-buster --build-arg base_image=debian:buster .
+docker build --build-arg build_image=rust:1.61-buster --build-arg base_image=debian:buster .
 ```
 which produces a debian-buster based image.


### PR DESCRIPTION
## Purpose

Migrate the transaction logger to V2 GRPC API.
This simplifies some of the waiting code since the update Rust SDK has methods to wait for new finalized blocks.

## Changes

- Bump minimum rust version to 1.61 to deal with new dependency versions.
- Make the necessary changes to the code to accommodate the new API.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
