### PR TITLE
Extract indexer infrastructure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
-  RUST_CLIPPY: 1.64
+  RUST_CLIPPY: 1.65
 
 jobs:
   "lint_fmt":

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,7 @@ name = "transaction-logger"
 version = "0.7.4"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "concordium-rust-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +231,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -289,6 +339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +373,16 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -343,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "bs58",
  "chrono",
@@ -373,6 +442,7 @@ dependencies = [
 name = "concordium-rust-sdk"
 version = "2.4.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "chrono",
  "concordium-smart-contract-engine",
@@ -381,6 +451,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "hex",
+ "http",
  "num",
  "num-bigint 0.4.3",
  "num-traits",
@@ -435,9 +506,12 @@ dependencies = [
 name = "concordium_base"
 version = "1.2.0"
 dependencies = [
+ "aes",
  "anyhow",
+ "base64 0.13.1",
  "bs58",
  "byteorder",
+ "cbc",
  "chrono",
  "concordium-contracts-common",
  "concordium_base_derive",
@@ -448,13 +522,16 @@ dependencies = [
  "ff",
  "group",
  "hex",
+ "hmac",
  "itertools",
  "leb128",
  "libc",
+ "nom",
  "num",
  "num-bigint 0.4.3",
  "num-traits",
  "pairing",
+ "pbkdf2",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
@@ -558,7 +635,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -867,6 +954,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "group"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1170,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1310,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1371,6 +1494,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.6",
+ "hmac",
+ "password-hash",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1571,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -2480,6 +2638,16 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ http = "0.2"
 tonic = {version = "0.8", features = ["tls", "tls-roots"]} # Use system trust roots.
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
+async-trait = "0.1.68"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,9 @@ use concordium_rust_sdk::{
     types::{hashes::BlockHash, AbsoluteBlockHeight},
     v2::{self, FinalizedBlockInfo},
 };
-use futures::future::BoxFuture;
 use structopt::StructOpt;
 use thiserror::Error;
-use tonic::transport::ClientTlsConfig;
+use tonic::{async_trait, transport::ClientTlsConfig};
 
 const MAX_CONNECT_ATTEMPTS: u64 = 6;
 
@@ -24,7 +23,7 @@ pub struct SharedIndexerArgs {
         use_delimiter = true,
         env = "TRANSACTION_LOGGER_NODES"
     )]
-    pub endpoint:        Vec<v2::Endpoint>,
+    pub endpoint: Vec<v2::Endpoint>,
     #[structopt(
         long = "db",
         default_value = "host=localhost dbname=transaction-outcome user=postgres \
@@ -32,14 +31,14 @@ pub struct SharedIndexerArgs {
         help = "Database connection string.",
         env = "TRANSACTION_LOGGER_DB_STRING"
     )]
-    pub config:          postgres::Config,
+    pub config: postgres::Config,
     #[structopt(
         long = "log-level",
         default_value = "off",
         help = "Maximum log level.",
         env = "TRANSACTION_LOGGER_LOG_LEVEL"
     )]
-    pub log_level:       log::LevelFilter,
+    pub log_level: log::LevelFilter,
     #[structopt(
         long = "num-parallel",
         default_value = "1",
@@ -48,7 +47,7 @@ pub struct SharedIndexerArgs {
                 take advantage of parallelism in queries.",
         env = "TRANSACTION_LOGGER_NUM_PARALLEL_QUERIES"
     )]
-    pub num_parallel:    u32,
+    pub num_parallel: u32,
     #[structopt(
         long = "max-behind-seconds",
         default_value = "240",
@@ -56,7 +55,7 @@ pub struct SharedIndexerArgs {
                 node is given up and another one is tried.",
         env = "TRANSACTION_LOGGER_MAX_BEHIND_SECONDS"
     )]
-    pub max_behind:      u32,
+    pub max_behind: u32,
     #[structopt(
         long = "connect-timeout",
         default_value = "10",
@@ -92,368 +91,745 @@ pub enum NodeError {
     OtherError(#[from] anyhow::Error),
 }
 
-pub struct Indexer<D, P>
-where
-    P: PrepareStatements, {
-    sql_schema:            String,
-    insert_into_db: Box<
-        dyn Fn(&mut DBConn<P>) -> BoxFuture<'static, Result<BlockInsertSuccess, postgres::Error>>
-            + Send
-            + Sync,
-    >,
-    get_stored_max_height: Box<
-        dyn Fn(
-                &DatabaseClient,
-            )
-                -> BoxFuture<'static, Result<Option<AbsoluteBlockHeight>, postgres::Error>>
-            + Send
-            + Sync,
-    >,
-    on_use_node:
-        Box<dyn Fn(&mut v2::Client) -> BoxFuture<'static, Result<(), NodeError>> + Send + Sync>,
-    on_finalized_block: Box<
-        dyn Fn(&mut v2::Client, &FinalizedBlockInfo) -> BoxFuture<'static, Result<D, NodeError>>
-            + Send
-            + Sync,
-    >,
+#[async_trait]
+pub trait DatabaseHooks<D, P> {
+    async fn insert_into_db(
+        db_conn: &mut DBConn<P>,
+        data: &D,
+    ) -> Result<BlockInsertSuccess, postgres::Error>;
+
+    async fn on_request_max_height(
+        db: &DatabaseClient,
+    ) -> Result<Option<AbsoluteBlockHeight>, postgres::Error>;
+
+    // async fn on_use_node(&self, client: &mut v2::Client) -> Result<(), NodeError>;
+
+    // async fn on_finalized_block(
+    //     &self,
+    //     client: &mut v2::Client,
+    //     finalized_block_info: &FinalizedBlockInfo,
+    // ) -> Result<D, NodeError>;
 }
 
-impl<D, P> Indexer<D, P>
+#[async_trait]
+pub trait NodeHooks<D> {
+    async fn on_use_node(&mut self, client: &mut v2::Client) -> Result<(), NodeError>;
+
+    async fn on_finalized_block(
+        &mut self,
+        client: &mut v2::Client,
+        finalized_block_info: &FinalizedBlockInfo,
+    ) -> Result<D, NodeError>;
+}
+
+// pub type InsertIntoDB<P, D> = Box<
+//     dyn Fn(&mut DBConn<P>, &D) -> BoxFuture<'static, Result<BlockInsertSuccess, postgres::Error>>
+//         + Send
+//         + Sync,
+// >;
+
+// pub type OnRequestMaxHeight = Box<
+//     dyn Fn(
+//             &DatabaseClient,
+//         ) -> BoxFuture<'static, Result<Option<AbsoluteBlockHeight>, postgres::Error>>
+//         + Send
+//         + Sync,
+// >;
+
+// pub type OnUseNode =
+//     Box<dyn Fn(&mut v2::Client) -> BoxFuture<'static, Result<(), NodeError>> + Send + Sync>;
+
+// pub type OnFinalizedBlock<D> = Box<
+//     dyn Fn(&mut v2::Client, &FinalizedBlockInfo) -> BoxFuture<'static, Result<D, NodeError>>
+//         + Send
+//         + Sync,
+// >;
+
+/// Try to reconnect to the database with exponential backoff, at most
+/// MAX_CONNECT_ATTEMPTS times.
+async fn try_reconnect<P>(
+    config: &postgres::Config,
+    sql_schema: &str,
+    stop_flag: &AtomicBool,
+    create_tables: bool,
+) -> anyhow::Result<DBConn<P>>
 where
-    P: PrepareStatements + Send,
-    D: Send,
+    P: PrepareStatements,
 {
-    pub async fn run(&'static self, app: SharedIndexerArgs) -> anyhow::Result<()> {
-        anyhow::ensure!(!app.endpoint.is_empty(), "At least one node must be provided.");
-        let config = app.config;
+    let mut i = 1;
+    let sql_opt: Option<&str> = if create_tables {
+        Some(sql_schema)
+    } else {
+        None
+    };
 
-        let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
-        // only log the current module (main).
-        log_builder.filter_module(module_path!(), app.log_level); // TODO: correct module?
-        log_builder.init();
-
-        // This program is set up as follows.
-        // It uses tokio to manage tasks. The reason for this is that it is the
-        // expectation that the main bottleneck is IO, either writing to the database or
-        // waiting for responses from the node.
-        // A background task is spawned whose only purpose is to write to the database.
-        // That task only terminates if the connection to the database is lost and
-        // cannot be established within half a minute or so (duration is governed by
-        // MAX_CONNECT_ATTEMPTS and exponential backoff).
-        //
-        // In the main task we query the nodes for block summaries. If querying the node
-        // fails, or the node is deemed too behind then we try the next node. The given
-        // nodes are tried in sequence and cycled when the end of the sequence is
-        // reached.
-        //
-        // The main task and the database writer task communicate via a bounded channel,
-        // with the main task sending block info and block summaries to the database
-        // writer thread.
-
-        // Since the database connection is managed by the background task we use a
-        // oneshot channel to get the height we should start querying at. First the
-        // background database task is started which then sends the height over this
-        // channel.
-        let (height_sender, height_receiver) = tokio::sync::oneshot::channel();
-        // Create a channel between the task querying the node and the task logging
-        // transactions.
-        let (sender, receiver) = tokio::sync::mpsc::channel(100);
-
-        let stop_flag = Arc::new(AtomicBool::new(false));
-
-        let shutdown_handler_handle = tokio::spawn(set_shutdown(stop_flag.clone()));
-
-        let db_write_handle =
-            tokio::spawn(self.write_to_db(config, height_sender, receiver, stop_flag.clone()));
-        // The height we should start querying the node at.
-        // If the sender died we simply terminate the program.
-        let mut height = height_receiver.await?;
-
-        // To make sure we do not end up in an infinite loop in case all reconnects fail
-        // we count reconnects. We deem a node connection successful if it increases
-        // maximum achieved height by at least 1.
-        let mut max_height = height;
-        let mut last_success = 0;
-        let num_nodes = app.endpoint.len() as u64;
-        for (node_ep, idx) in app.endpoint.into_iter().cycle().zip(0u64..) {
-            if stop_flag.load(Ordering::Acquire) {
-                break;
-            }
-            if idx.saturating_sub(last_success) >= num_nodes {
-                // we skipped all the nodes without success.
-                let delay = std::time::Duration::from_secs(5);
+    while !stop_flag.load(Ordering::Acquire) {
+        match DBConn::create(config, sql_opt).await {
+            Ok(c) => return Ok(c),
+            Err(e) if i < MAX_CONNECT_ATTEMPTS => {
+                let delay = std::time::Duration::from_millis(500 * (1 << i));
                 log::error!(
-                    "Connections to all nodes have failed. Pausing for {}s before trying node {} \
-                     again.",
-                    delay.as_secs(),
-                    node_ep.uri()
+                    "Could not connect to the database due to {:#}. Reconnecting in {}ms",
+                    e,
+                    delay.as_millis()
                 );
+                // wait for 2^(i-1) seconds before attempting to reconnect.
                 tokio::time::sleep(delay).await;
+                i += 1;
             }
-            // connect to the node.
-            log::info!("Attempting to use node {}", node_ep.uri());
-
-            let node_ep = node_ep
-                .connect_timeout(std::time::Duration::from_secs(app.connect_timeout.into()))
-                .timeout(std::time::Duration::from_secs(app.request_timeout.into()));
-
-            let node_result = self
-                .node_process(
-                    node_ep,
-                    &sender,
-                    &mut height,
-                    app.num_parallel,
-                    stop_flag.as_ref(),
-                    app.max_behind,
-                )
-                .await;
-
-            match node_result {
-                Err(NodeError::ConnectionError(e)) => {
-                    log::warn!(
-                        "Failed to connect to node due to {:#}. Will attempt another node.",
-                        e
-                    );
-                }
-                Err(NodeError::OtherError(e)) => {
-                    log::warn!("Node query failed due to: {:#}. Will attempt another node.", e);
-                }
-                Err(NodeError::NetworkError(e)) => {
-                    log::warn!(
-                        "Failed to connect to node due to {:#}. Will attempt another node.",
-                        e
-                    );
-                }
-                Err(NodeError::QueryError(e)) => {
-                    log::warn!(
-                        "Failed to connect to node due to {:#}. Will attempt another node.",
-                        e
-                    );
-                }
-                Err(NodeError::Timeout) => {
-                    log::warn!("Node too far behind. Will attempt another node.");
-                }
-                Ok(()) => break,
-            }
-            if height > max_height {
-                last_success = idx;
-                max_height = height;
+            Err(e) => {
+                log::error!(
+                    "Could not connect to the database in {} attempts. Last attempt failed \
+                         with reason {:#}.",
+                    MAX_CONNECT_ATTEMPTS,
+                    e
+                );
+                return Err(e);
             }
         }
-        db_write_handle.abort();
-        shutdown_handler_handle.abort();
-        Ok(())
     }
+    anyhow::bail!("The node was requested to stop.")
+}
 
-    /// Return Err if querying the node failed.
-    /// Return Ok(()) if the channel to the database was closed.
-    #[allow(clippy::too_many_arguments)]
-    async fn node_process(
-        &self,
-        node_ep: v2::Endpoint,
-        sender: &tokio::sync::mpsc::Sender<D>,
-        height: &mut AbsoluteBlockHeight, // start height
-        max_parallel: u32,
-        stop_flag: &AtomicBool,
-        max_behind: u32, /* maximum number of seconds a node can be behind before it is deemed
-                          * "behind" */
-    ) -> Result<(), NodeError> {
-        // Use TLS if the URI scheme is HTTPS.
-        // This uses whatever system certificates have been installed as trusted roots.
-        let node_ep = if node_ep.uri().scheme().map_or(false, |x| x == &http::uri::Scheme::HTTPS) {
-            node_ep.tls_config(ClientTlsConfig::new()).map_err(NodeError::ConnectionError)?
+async fn write_to_db<D, P, H>(
+    config: postgres::Config,
+    sql_schema: &str,
+    start_from_sender: tokio::sync::oneshot::Sender<AbsoluteBlockHeight>, // start height
+    mut receiver: tokio::sync::mpsc::Receiver<D>,
+    stop_flag: Arc<AtomicBool>,
+) -> anyhow::Result<()>
+where
+    P: PrepareStatements,
+    H: DatabaseHooks<D, P>,
+{
+    let mut db = try_reconnect(&config, sql_schema, &stop_flag, true).await?;
+
+    let start_from = H::on_request_max_height(&db.client).await?.map_or(0.into(), |h| h.next());
+    start_from_sender
+        .send(start_from)
+        .map_err(|_| anyhow::anyhow!("Cannot send start height value to the node worker."))?;
+    let mut retry = None;
+    // How many successive insertion errors were encountered.
+    // This is used to slow down attempts to not spam the database
+    let mut successive_errors = 0;
+    while !stop_flag.load(Ordering::Acquire) {
+        let next_item = if let Some(v) = retry.take() {
+            Some(v)
         } else {
-            node_ep
+            receiver.recv().await
         };
-
-        let mut node = v2::Client::new(node_ep).await.map_err(NodeError::ConnectionError)?;
-        while !stop_flag.load(Ordering::Acquire) {
-            (self.on_use_node)(&mut node).await?;
-
-            let timeout = std::time::Duration::from_secs(max_behind.into());
-            let mut finalized_blocks = node.get_finalized_blocks_from(*height).await?;
-
-            let (has_error, chunks) = finalized_blocks
-                .next_chunk_timeout(max_parallel as usize, timeout)
-                .await
-                .map_err(|_| NodeError::Timeout)?;
-
-            for fb in chunks {
-                let d = (self.on_finalized_block)(&mut node, &fb).await?;
-
-                if sender.send(d).await.is_err() {
-                    log::error!(
-                        "The database connection has been closed. Terminating node queries."
+        if let Some(data) = next_item {
+            match H::insert_into_db(&mut db, &data).await {
+                Ok(success) => {
+                    successive_errors = 0;
+                    log::info!(
+                        "Processed block {} at height {} in {}ms.",
+                        success.block_hash,
+                        success.block_height,
+                        success.time.num_milliseconds()
                     );
-                    return Ok(());
                 }
-
-                *height = height.next();
-            }
-
-            if has_error {
-                // we have processed the blocks we can, but further queries on the same stream
-                // will fail since the stream signalled an error.
-                return Err(NodeError::OtherError(anyhow::anyhow!(
-                    "Finalized block stream dropped."
-                )));
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Try to reconnect to the database with exponential backoff, at most
-    /// MAX_CONNECT_ATTEMPTS times.
-    async fn try_reconnect(
-        &self,
-        config: &postgres::Config,
-        stop_flag: &AtomicBool,
-        create_tables: bool,
-    ) -> anyhow::Result<DBConn<P>> {
-        let mut i = 1;
-        let sql_opt: Option<&str> = if create_tables {
-            Some(&self.sql_schema)
-        } else {
-            None
-        };
-
-        while !stop_flag.load(Ordering::Acquire) {
-            match DBConn::create(config, sql_opt).await {
-                Ok(c) => return Ok(c),
-                Err(e) if i < MAX_CONNECT_ATTEMPTS => {
-                    let delay = std::time::Duration::from_millis(500 * (1 << i));
+                Err(e) => {
+                    successive_errors += 1;
+                    // wait for 2^(min(successive_errors - 1, 7)) seconds before attempting.
+                    // The reason for the min is that we bound the time between reconnects.
+                    let delay = std::time::Duration::from_millis(
+                        500 * (1 << std::cmp::min(successive_errors, 8)),
+                    );
                     log::error!(
-                        "Could not connect to the database due to {:#}. Reconnecting in {}ms",
+                        "Database connection lost due to {:#}. Will attempt to reconnect in \
+                             {}ms.",
                         e,
                         delay.as_millis()
                     );
-                    // wait for 2^(i-1) seconds before attempting to reconnect.
                     tokio::time::sleep(delay).await;
-                    i += 1;
-                }
-                Err(e) => {
-                    log::error!(
-                        "Could not connect to the database in {} attempts. Last attempt failed \
-                         with reason {:#}.",
-                        MAX_CONNECT_ATTEMPTS,
-                        e
-                    );
-                    return Err(e);
-                }
-            }
-        }
-        anyhow::bail!("The node was requested to stop.")
-    }
-
-    async fn write_to_db(
-        &self,
-        config: postgres::Config,
-        start_from_sender: tokio::sync::oneshot::Sender<AbsoluteBlockHeight>, // start height
-        mut receiver: tokio::sync::mpsc::Receiver<D>,
-        stop_flag: Arc<AtomicBool>,
-    ) -> anyhow::Result<()> {
-        let mut db = self.try_reconnect(&config, &stop_flag, true).await?;
-
-        let start_from =
-            (self.get_stored_max_height)(&db.client).await?.map_or(0.into(), |h| h.next());
-        start_from_sender
-            .send(start_from)
-            .map_err(|_| anyhow::anyhow!("Cannot send start height value to the node worker."))?;
-        let mut retry = None;
-        // How many successive insertion errors were encountered.
-        // This is used to slow down attempts to not spam the database
-        let mut successive_errors = 0;
-        while !stop_flag.load(Ordering::Acquire) {
-            let next_item = if let Some(v) = retry.take() {
-                Some(v)
-            } else {
-                receiver.recv().await
-            };
-            if let Some(data) = next_item {
-                match (self.insert_into_db)(&mut db).await {
-                    Ok(success) => {
-                        successive_errors = 0;
-                        log::info!(
-                            "Processed block {} at height {} in {}ms.",
-                            success.block_hash,
-                            success.block_height,
-                            success.time.num_milliseconds()
-                        );
-                    }
-                    Err(e) => {
-                        successive_errors += 1;
-                        // wait for 2^(min(successive_errors - 1, 7)) seconds before attempting.
-                        // The reason for the min is that we bound the time between reconnects.
-                        let delay = std::time::Duration::from_millis(
-                            500 * (1 << std::cmp::min(successive_errors, 8)),
-                        );
-                        log::error!(
-                            "Database connection lost due to {:#}. Will attempt to reconnect in \
-                             {}ms.",
-                            e,
-                            delay.as_millis()
-                        );
-                        tokio::time::sleep(delay).await;
-                        let new_db = match self.try_reconnect(&config, &stop_flag, false).await {
-                            Ok(db) => db,
-                            Err(e) => {
-                                receiver.close();
-                                return Err(e);
-                            }
-                        };
-                        // and drop the old database.
-                        let old_db = std::mem::replace(&mut db, new_db);
-                        match old_db.client.stop().await {
-                            Ok(v) => {
-                                if let Err(e) = v {
-                                    log::warn!(
-                                        "Could not correctly stop the old database connection due \
+                    let new_db = match try_reconnect(&config, sql_schema, &stop_flag, false).await {
+                        Ok(db) => db,
+                        Err(e) => {
+                            receiver.close();
+                            return Err(e);
+                        }
+                    };
+                    // and drop the old database.
+                    let old_db = std::mem::replace(&mut db, new_db);
+                    match old_db.client.stop().await {
+                        Ok(v) => {
+                            if let Err(e) = v {
+                                log::warn!(
+                                    "Could not correctly stop the old database connection due \
                                          to: {}.",
-                                        e
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                if e.is_panic() {
-                                    log::warn!(
-                                        "Could not correctly stop the old database connection. \
-                                         The connection thread panicked."
-                                    );
-                                } else {
-                                    log::warn!(
-                                        "Could not correctly stop the old database connection."
-                                    );
-                                }
+                                    e
+                                );
                             }
                         }
-                        retry = Some(data);
+                        Err(e) => {
+                            if e.is_panic() {
+                                log::warn!(
+                                    "Could not correctly stop the old database connection. \
+                                         The connection thread panicked."
+                                );
+                            } else {
+                                log::warn!("Could not correctly stop the old database connection.");
+                            }
+                        }
                     }
+                    retry = Some(data);
                 }
-            } else {
-                break;
             }
+        } else {
+            break;
         }
-        // stop the database connection.
-        receiver.close();
-        db.client.stop().await??;
-        Ok(())
     }
+    // stop the database connection.
+    receiver.close();
+    db.client.stop().await??;
+    Ok(())
 }
 
+/// Return Err if querying the node failed.
+/// Return Ok(()) if the channel to the database was closed.
+#[allow(clippy::too_many_arguments)]
+async fn node_process<D, H>(
+    node_ep: v2::Endpoint,
+    sender: &tokio::sync::mpsc::Sender<D>,
+    height: &mut AbsoluteBlockHeight, // start height
+    max_parallel: u32,
+    stop_flag: &AtomicBool,
+    max_behind: u32, /* maximum number of seconds a node can be behind before it is deemed "behind" */
+    hooks: &mut H,
+) -> Result<(), NodeError>
+where
+    H: NodeHooks<D>,
+{
+    // Use TLS if the URI scheme is HTTPS.
+    // This uses whatever system certificates have been installed as trusted roots.
+    let node_ep = if node_ep.uri().scheme().map_or(false, |x| x == &http::uri::Scheme::HTTPS) {
+        node_ep.tls_config(ClientTlsConfig::new()).map_err(NodeError::ConnectionError)?
+    } else {
+        node_ep
+    };
+
+    let mut node = v2::Client::new(node_ep).await.map_err(NodeError::ConnectionError)?;
+    while !stop_flag.load(Ordering::Acquire) {
+        hooks.on_use_node(&mut node).await?;
+
+        let timeout = std::time::Duration::from_secs(max_behind.into());
+        let mut finalized_blocks = node.get_finalized_blocks_from(*height).await?;
+
+        let (has_error, chunks) = finalized_blocks
+            .next_chunk_timeout(max_parallel as usize, timeout)
+            .await
+            .map_err(|_| NodeError::Timeout)?;
+
+        for fb in chunks {
+            let d = hooks.on_finalized_block(&mut node, &fb).await?;
+
+            if sender.send(d).await.is_err() {
+                log::error!("The database connection has been closed. Terminating node queries.");
+                return Ok(());
+            }
+
+            *height = height.next();
+        }
+
+        if has_error {
+            // we have processed the blocks we can, but further queries on the same stream
+            // will fail since the stream signalled an error.
+            return Err(NodeError::OtherError(anyhow::anyhow!("Finalized block stream dropped.")));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn run_service<D, P, DH, NH>(
+    sql_schema: &'static str,
+    app_config: SharedIndexerArgs,
+    mut node_hooks: NH,
+) -> Result<(), anyhow::Error>
+where
+    P: PrepareStatements + Send + 'static,
+    D: Send + Sync + 'static,
+    DH: DatabaseHooks<D, P> + Send + Sync + 'static,
+    NH: NodeHooks<D>,
+{
+    anyhow::ensure!(!app_config.endpoint.is_empty(), "At least one node must be provided.");
+    let config = app_config.config;
+
+    let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
+    // only log the current module (main).
+    log_builder.filter_module(module_path!(), app_config.log_level); // TODO: correct module?
+    log_builder.init();
+
+    // This program is set up as follows.
+    // It uses tokio to manage tasks. The reason for this is that it is the
+    // expectation that the main bottleneck is IO, either writing to the database or
+    // waiting for responses from the node.
+    // A background task is spawned whose only purpose is to write to the database.
+    // That task only terminates if the connection to the database is lost and
+    // cannot be established within half a minute or so (duration is governed by
+    // MAX_CONNECT_ATTEMPTS and exponential backoff).
+    //
+    // In the main task we query the nodes for block summaries. If querying the node
+    // fails, or the node is deemed too behind then we try the next node. The given
+    // nodes are tried in sequence and cycled when the end of the sequence is
+    // reached.
+    //
+    // The main task and the database writer task communicate via a bounded channel,
+    // with the main task sending block info and block summaries to the database
+    // writer thread.
+
+    // Since the database connection is managed by the background task we use a
+    // oneshot channel to get the height we should start querying at. First the
+    // background database task is started which then sends the height over this
+    // channel.
+    let (height_sender, height_receiver) = tokio::sync::oneshot::channel();
+    // Create a channel between the task querying the node and the task logging
+    // transactions.
+    let (sender, receiver) = tokio::sync::mpsc::channel(100);
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+
+    let shutdown_handler_handle = tokio::spawn(set_shutdown(stop_flag.clone()));
+
+    let db_write_handle = tokio::spawn(write_to_db::<D, P, DH>(
+        config,
+        sql_schema,
+        height_sender,
+        receiver,
+        stop_flag.clone(),
+    ));
+    // The height we should start querying the node at.
+    // If the sender died we simply terminate the program.
+    let mut height = height_receiver.await?;
+
+    // To make sure we do not end up in an infinite loop in case all reconnects fail
+    // we count reconnects. We deem a node connection successful if it increases
+    // maximum achieved height by at least 1.
+    let mut max_height = height;
+    let mut last_success = 0;
+    let num_nodes = app_config.endpoint.len() as u64;
+    for (node_ep, idx) in app_config.endpoint.into_iter().cycle().zip(0u64..) {
+        if stop_flag.load(Ordering::Acquire) {
+            break;
+        }
+        if idx.saturating_sub(last_success) >= num_nodes {
+            // we skipped all the nodes without success.
+            let delay = std::time::Duration::from_secs(5);
+            log::error!(
+                "Connections to all nodes have failed. Pausing for {}s before trying node {} \
+                     again.",
+                delay.as_secs(),
+                node_ep.uri()
+            );
+            tokio::time::sleep(delay).await;
+        }
+        // connect to the node.
+        log::info!("Attempting to use node {}", node_ep.uri());
+
+        let node_ep = node_ep
+            .connect_timeout(std::time::Duration::from_secs(app_config.connect_timeout.into()))
+            .timeout(std::time::Duration::from_secs(app_config.request_timeout.into()));
+
+        let node_result = node_process(
+            node_ep,
+            &sender,
+            &mut height,
+            app_config.num_parallel,
+            stop_flag.as_ref(),
+            app_config.max_behind,
+            &mut node_hooks,
+        )
+        .await;
+
+        match node_result {
+            Err(NodeError::ConnectionError(e)) => {
+                log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
+            }
+            Err(NodeError::OtherError(e)) => {
+                log::warn!("Node query failed due to: {:#}. Will attempt another node.", e);
+            }
+            Err(NodeError::NetworkError(e)) => {
+                log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
+            }
+            Err(NodeError::QueryError(e)) => {
+                log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
+            }
+            Err(NodeError::Timeout) => {
+                log::warn!("Node too far behind. Will attempt another node.");
+            }
+            Ok(()) => break,
+        }
+        if height > max_height {
+            last_success = idx;
+            max_height = height;
+        }
+    }
+    db_write_handle.abort();
+    shutdown_handler_handle.abort();
+    Ok(())
+}
+
+// pub struct Indexer<D, P, H>
+// where
+//     P: PrepareStatements + Send,
+//     D: Send + Sync,
+//     H: DatabaseHooks<D, P>,
+// {
+//     sql_schema: String,
+//     phantom_p: PhantomData<P>,
+//     phantom_d: PhantomData<D>,
+//     hooks: H,
+// }
+
+// impl<D, P, H> Indexer<D, P, H>
+// where
+//     P: PrepareStatements + Send + Sync,
+//     D: Send + Sync,
+//     H: DatabaseHooks<D, P> + Send + Sync,
+// {
+//     pub fn new(sql_schema: String, hooks: H) -> Self {
+//         Self {
+//             sql_schema,
+//             hooks,
+//             phantom_p: PhantomData,
+//             phantom_d: PhantomData,
+//         }
+//     }
+//     pub async fn run(&'static self, app: SharedIndexerArgs) -> anyhow::Result<()> {
+//         anyhow::ensure!(!app.endpoint.is_empty(), "At least one node must be provided.");
+//         let config = app.config;
+
+//         let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
+//         // only log the current module (main).
+//         log_builder.filter_module(module_path!(), app.log_level); // TODO: correct module?
+//         log_builder.init();
+
+//         // This program is set up as follows.
+//         // It uses tokio to manage tasks. The reason for this is that it is the
+//         // expectation that the main bottleneck is IO, either writing to the database or
+//         // waiting for responses from the node.
+//         // A background task is spawned whose only purpose is to write to the database.
+//         // That task only terminates if the connection to the database is lost and
+//         // cannot be established within half a minute or so (duration is governed by
+//         // MAX_CONNECT_ATTEMPTS and exponential backoff).
+//         //
+//         // In the main task we query the nodes for block summaries. If querying the node
+//         // fails, or the node is deemed too behind then we try the next node. The given
+//         // nodes are tried in sequence and cycled when the end of the sequence is
+//         // reached.
+//         //
+//         // The main task and the database writer task communicate via a bounded channel,
+//         // with the main task sending block info and block summaries to the database
+//         // writer thread.
+
+//         // Since the database connection is managed by the background task we use a
+//         // oneshot channel to get the height we should start querying at. First the
+//         // background database task is started which then sends the height over this
+//         // channel.
+//         let (height_sender, height_receiver) = tokio::sync::oneshot::channel();
+//         // Create a channel between the task querying the node and the task logging
+//         // transactions.
+//         let (sender, receiver) = tokio::sync::mpsc::channel(100);
+
+//         let stop_flag = Arc::new(AtomicBool::new(false));
+
+//         let shutdown_handler_handle = tokio::spawn(set_shutdown(stop_flag.clone()));
+
+//         let db_write_handle =
+//             tokio::spawn(self.write_to_db(config, height_sender, receiver, stop_flag.clone()));
+//         // The height we should start querying the node at.
+//         // If the sender died we simply terminate the program.
+//         let mut height = height_receiver.await?;
+
+//         // To make sure we do not end up in an infinite loop in case all reconnects fail
+//         // we count reconnects. We deem a node connection successful if it increases
+//         // maximum achieved height by at least 1.
+//         let mut max_height = height;
+//         let mut last_success = 0;
+//         let num_nodes = app.endpoint.len() as u64;
+//         for (node_ep, idx) in app.endpoint.into_iter().cycle().zip(0u64..) {
+//             if stop_flag.load(Ordering::Acquire) {
+//                 break;
+//             }
+//             if idx.saturating_sub(last_success) >= num_nodes {
+//                 // we skipped all the nodes without success.
+//                 let delay = std::time::Duration::from_secs(5);
+//                 log::error!(
+//                     "Connections to all nodes have failed. Pausing for {}s before trying node {} \
+//                      again.",
+//                     delay.as_secs(),
+//                     node_ep.uri()
+//                 );
+//                 tokio::time::sleep(delay).await;
+//             }
+//             // connect to the node.
+//             log::info!("Attempting to use node {}", node_ep.uri());
+
+//             let node_ep = node_ep
+//                 .connect_timeout(std::time::Duration::from_secs(app.connect_timeout.into()))
+//                 .timeout(std::time::Duration::from_secs(app.request_timeout.into()));
+
+//             let node_result = self
+//                 .node_process(
+//                     node_ep,
+//                     &sender,
+//                     &mut height,
+//                     app.num_parallel,
+//                     stop_flag.as_ref(),
+//                     app.max_behind,
+//                 )
+//                 .await;
+
+//             match node_result {
+//                 Err(NodeError::ConnectionError(e)) => {
+//                     log::warn!(
+//                         "Failed to connect to node due to {:#}. Will attempt another node.",
+//                         e
+//                     );
+//                 }
+//                 Err(NodeError::OtherError(e)) => {
+//                     log::warn!("Node query failed due to: {:#}. Will attempt another node.", e);
+//                 }
+//                 Err(NodeError::NetworkError(e)) => {
+//                     log::warn!(
+//                         "Failed to connect to node due to {:#}. Will attempt another node.",
+//                         e
+//                     );
+//                 }
+//                 Err(NodeError::QueryError(e)) => {
+//                     log::warn!(
+//                         "Failed to connect to node due to {:#}. Will attempt another node.",
+//                         e
+//                     );
+//                 }
+//                 Err(NodeError::Timeout) => {
+//                     log::warn!("Node too far behind. Will attempt another node.");
+//                 }
+//                 Ok(()) => break,
+//             }
+//             if height > max_height {
+//                 last_success = idx;
+//                 max_height = height;
+//             }
+//         }
+//         db_write_handle.abort();
+//         shutdown_handler_handle.abort();
+//         Ok(())
+//     }
+
+//     /// Return Err if querying the node failed.
+//     /// Return Ok(()) if the channel to the database was closed.
+//     #[allow(clippy::too_many_arguments)]
+//     async fn node_process(
+//         &self,
+//         node_ep: v2::Endpoint,
+//         sender: &tokio::sync::mpsc::Sender<D>,
+//         height: &mut AbsoluteBlockHeight, // start height
+//         max_parallel: u32,
+//         stop_flag: &AtomicBool,
+//         max_behind: u32, /* maximum number of seconds a node can be behind before it is deemed
+//                           * "behind" */
+//     ) -> Result<(), NodeError> {
+//         // Use TLS if the URI scheme is HTTPS.
+//         // This uses whatever system certificates have been installed as trusted roots.
+//         let node_ep = if node_ep.uri().scheme().map_or(false, |x| x == &http::uri::Scheme::HTTPS) {
+//             node_ep.tls_config(ClientTlsConfig::new()).map_err(NodeError::ConnectionError)?
+//         } else {
+//             node_ep
+//         };
+
+//         let mut node = v2::Client::new(node_ep).await.map_err(NodeError::ConnectionError)?;
+//         while !stop_flag.load(Ordering::Acquire) {
+//             self.hooks.on_use_node(&mut node).await?;
+
+//             let timeout = std::time::Duration::from_secs(max_behind.into());
+//             let mut finalized_blocks = node.get_finalized_blocks_from(*height).await?;
+
+//             let (has_error, chunks) = finalized_blocks
+//                 .next_chunk_timeout(max_parallel as usize, timeout)
+//                 .await
+//                 .map_err(|_| NodeError::Timeout)?;
+
+//             for fb in chunks {
+//                 let d = self.hooks.on_finalized_block(&mut node, &fb).await?;
+
+//                 if sender.send(d).await.is_err() {
+//                     log::error!(
+//                         "The database connection has been closed. Terminating node queries."
+//                     );
+//                     return Ok(());
+//                 }
+
+//                 *height = height.next();
+//             }
+
+//             if has_error {
+//                 // we have processed the blocks we can, but further queries on the same stream
+//                 // will fail since the stream signalled an error.
+//                 return Err(NodeError::OtherError(anyhow::anyhow!(
+//                     "Finalized block stream dropped."
+//                 )));
+//             }
+//         }
+
+//         Ok(())
+//     }
+
+//     /// Try to reconnect to the database with exponential backoff, at most
+//     /// MAX_CONNECT_ATTEMPTS times.
+//     async fn try_reconnect(
+//         &self,
+//         config: &postgres::Config,
+//         stop_flag: &AtomicBool,
+//         create_tables: bool,
+//     ) -> anyhow::Result<DBConn<P>> {
+//         let mut i = 1;
+//         let sql_opt: Option<&str> = if create_tables {
+//             Some(&self.sql_schema)
+//         } else {
+//             None
+//         };
+
+//         while !stop_flag.load(Ordering::Acquire) {
+//             match DBConn::create(config, sql_opt).await {
+//                 Ok(c) => return Ok(c),
+//                 Err(e) if i < MAX_CONNECT_ATTEMPTS => {
+//                     let delay = std::time::Duration::from_millis(500 * (1 << i));
+//                     log::error!(
+//                         "Could not connect to the database due to {:#}. Reconnecting in {}ms",
+//                         e,
+//                         delay.as_millis()
+//                     );
+//                     // wait for 2^(i-1) seconds before attempting to reconnect.
+//                     tokio::time::sleep(delay).await;
+//                     i += 1;
+//                 }
+//                 Err(e) => {
+//                     log::error!(
+//                         "Could not connect to the database in {} attempts. Last attempt failed \
+//                          with reason {:#}.",
+//                         MAX_CONNECT_ATTEMPTS,
+//                         e
+//                     );
+//                     return Err(e);
+//                 }
+//             }
+//         }
+//         anyhow::bail!("The node was requested to stop.")
+//     }
+
+//     async fn write_to_db(
+//         &self,
+//         config: postgres::Config,
+//         start_from_sender: tokio::sync::oneshot::Sender<AbsoluteBlockHeight>, // start height
+//         mut receiver: tokio::sync::mpsc::Receiver<D>,
+//         stop_flag: Arc<AtomicBool>,
+//     ) -> anyhow::Result<()> {
+//         let mut db = self.try_reconnect(&config, &stop_flag, true).await?;
+
+//         let start_from =
+//             self.hooks.on_request_max_height(&db.client).await?.map_or(0.into(), |h| h.next());
+//         start_from_sender
+//             .send(start_from)
+//             .map_err(|_| anyhow::anyhow!("Cannot send start height value to the node worker."))?;
+//         let mut retry = None;
+//         // How many successive insertion errors were encountered.
+//         // This is used to slow down attempts to not spam the database
+//         let mut successive_errors = 0;
+//         while !stop_flag.load(Ordering::Acquire) {
+//             let next_item = if let Some(v) = retry.take() {
+//                 Some(v)
+//             } else {
+//                 receiver.recv().await
+//             };
+//             if let Some(data) = next_item {
+//                 match self.hooks.insert_into_db(&mut db, &data).await {
+//                     Ok(success) => {
+//                         successive_errors = 0;
+//                         log::info!(
+//                             "Processed block {} at height {} in {}ms.",
+//                             success.block_hash,
+//                             success.block_height,
+//                             success.time.num_milliseconds()
+//                         );
+//                     }
+//                     Err(e) => {
+//                         successive_errors += 1;
+//                         // wait for 2^(min(successive_errors - 1, 7)) seconds before attempting.
+//                         // The reason for the min is that we bound the time between reconnects.
+//                         let delay = std::time::Duration::from_millis(
+//                             500 * (1 << std::cmp::min(successive_errors, 8)),
+//                         );
+//                         log::error!(
+//                             "Database connection lost due to {:#}. Will attempt to reconnect in \
+//                              {}ms.",
+//                             e,
+//                             delay.as_millis()
+//                         );
+//                         tokio::time::sleep(delay).await;
+//                         let new_db = match self.try_reconnect(&config, &stop_flag, false).await {
+//                             Ok(db) => db,
+//                             Err(e) => {
+//                                 receiver.close();
+//                                 return Err(e);
+//                             }
+//                         };
+//                         // and drop the old database.
+//                         let old_db = std::mem::replace(&mut db, new_db);
+//                         match old_db.client.stop().await {
+//                             Ok(v) => {
+//                                 if let Err(e) = v {
+//                                     log::warn!(
+//                                         "Could not correctly stop the old database connection due \
+//                                          to: {}.",
+//                                         e
+//                                     );
+//                                 }
+//                             }
+//                             Err(e) => {
+//                                 if e.is_panic() {
+//                                     log::warn!(
+//                                         "Could not correctly stop the old database connection. \
+//                                          The connection thread panicked."
+//                                     );
+//                                 } else {
+//                                     log::warn!(
+//                                         "Could not correctly stop the old database connection."
+//                                     );
+//                                 }
+//                             }
+//                         }
+//                         retry = Some(data);
+//                     }
+//                 }
+//             } else {
+//                 break;
+//             }
+//         }
+//         // stop the database connection.
+//         receiver.close();
+//         db.client.stop().await??;
+//         Ok(())
+//     }
+// }
+
+#[async_trait]
 pub trait PrepareStatements {
-    fn prepare_all(client: &mut DatabaseClient) -> Self;
+    async fn prepare_all(client: &mut DatabaseClient) -> Result<Self, postgres::Error>
+    where
+        Self: Sized;
 }
 
 pub struct BlockInsertSuccess {
-    pub time:         chrono::Duration,
-    pub block_hash:   BlockHash,
+    pub time: chrono::Duration,
+    pub block_hash: BlockHash,
     pub block_height: AbsoluteBlockHeight,
 }
 
 /// A wrapper around a [`DatabaseClient`] that maintains prepared statements.
 pub struct DBConn<P> {
-    pub client:   DatabaseClient,
+    pub client: DatabaseClient,
     pub prepared: P,
 }
 
@@ -463,14 +839,17 @@ impl<P: PrepareStatements> DBConn<P> {
     /// `resources/schema.sql`). This script is in principle idempotent so
     /// running it twice should be safe, but it is also needless,
     /// so this should only be requested on a first connection on startup.
-    async fn create(config: &postgres::Config, try_run_sql: Option<&str>) -> anyhow::Result<Self> {
+    pub async fn create(
+        config: &postgres::Config,
+        try_run_sql: Option<&str>,
+    ) -> anyhow::Result<Self> {
         let mut client = DatabaseClient::create(config.clone(), postgres::NoTls).await?;
 
         if let Some(sql) = try_run_sql {
             client.as_ref().batch_execute(sql).await?
         }
 
-        let prepared = P::prepare_all(&mut client);
+        let prepared = P::prepare_all(&mut client).await?;
 
         Ok(Self {
             client,
@@ -478,7 +857,19 @@ impl<P: PrepareStatements> DBConn<P> {
         })
     }
 }
-///
+
+impl<P> AsRef<DatabaseClient> for DBConn<P> {
+    fn as_ref(&self) -> &DatabaseClient {
+        &self.client
+    }
+}
+
+impl<P> AsMut<DatabaseClient> for DBConn<P> {
+    fn as_mut(&mut self) -> &mut DatabaseClient {
+        &mut self.client
+    }
+}
+
 /// Construct a future for shutdown signals (for unix: SIGINT and SIGTERM) (for
 /// windows: ctrl c and ctrl break). The signal handler is set when the future
 /// is polled and until then the default signal handler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,507 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use concordium_rust_sdk::{
+    postgres::{self, DatabaseClient},
+    types::{hashes::BlockHash, AbsoluteBlockHeight},
+    v2::{self, FinalizedBlockInfo},
+};
+use futures::future::BoxFuture;
+use structopt::StructOpt;
+use thiserror::Error;
+use tonic::transport::ClientTlsConfig;
+
+const MAX_CONNECT_ATTEMPTS: u64 = 6;
+
+#[derive(StructOpt)]
+pub struct SharedIndexerArgs {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node(s).",
+        default_value = "http://localhost:20000",
+        use_delimiter = true,
+        env = "TRANSACTION_LOGGER_NODES"
+    )]
+    pub endpoint:        Vec<v2::Endpoint>,
+    #[structopt(
+        long = "db",
+        default_value = "host=localhost dbname=transaction-outcome user=postgres \
+                         password=password port=5432",
+        help = "Database connection string.",
+        env = "TRANSACTION_LOGGER_DB_STRING"
+    )]
+    pub config:          postgres::Config,
+    #[structopt(
+        long = "log-level",
+        default_value = "off",
+        help = "Maximum log level.",
+        env = "TRANSACTION_LOGGER_LOG_LEVEL"
+    )]
+    pub log_level:       log::LevelFilter,
+    #[structopt(
+        long = "num-parallel",
+        default_value = "1",
+        help = "Maximum number of parallel queries to make to the node. Usually 1 is the correct \
+                number, but during initial catchup it is useful to increase this to, say 8 to \
+                take advantage of parallelism in queries.",
+        env = "TRANSACTION_LOGGER_NUM_PARALLEL_QUERIES"
+    )]
+    pub num_parallel:    u32,
+    #[structopt(
+        long = "max-behind-seconds",
+        default_value = "240",
+        help = "Maximum number of seconds the node's last finalization can be behind before the \
+                node is given up and another one is tried.",
+        env = "TRANSACTION_LOGGER_MAX_BEHIND_SECONDS"
+    )]
+    pub max_behind:      u32,
+    #[structopt(
+        long = "connect-timeout",
+        default_value = "10",
+        help = "Connection timeout for connecting to the node, in seconds",
+        env = "TRANSACTION_LOGGER_CONNECT_TIMEOUT"
+    )]
+    pub connect_timeout: u32,
+    #[structopt(
+        long = "request-timeout",
+        default_value = "60",
+        help = "Request timeout for node requests, in seconds",
+        env = "TRANSACTION_LOGGER_REQUEST_TIMEOUT"
+    )]
+    pub request_timeout: u32,
+}
+
+#[derive(Debug, Error)]
+pub enum NodeError {
+    /// Error establishing connection.
+    #[error("Error connecting to the node {0}.")]
+    ConnectionError(tonic::transport::Error),
+    /// No finalization in some time.
+    #[error("Timeout.")]
+    Timeout,
+    /// Error establishing connection.
+    #[error("Error during query {0}.")]
+    NetworkError(#[from] v2::Status),
+    /// Query error.
+    #[error("Error querying the node {0}.")]
+    QueryError(#[from] v2::QueryError),
+    /// Query errors, etc.
+    #[error("Error querying the node {0}.")]
+    OtherError(#[from] anyhow::Error),
+}
+
+pub struct Indexer<D, P>
+where
+    P: PrepareStatements, {
+    sql_schema:            String,
+    insert_into_db: Box<
+        dyn Fn(&mut DBConn<P>) -> BoxFuture<'static, Result<BlockInsertSuccess, postgres::Error>>
+            + Send
+            + Sync,
+    >,
+    get_stored_max_height: Box<
+        dyn Fn(
+                &DatabaseClient,
+            )
+                -> BoxFuture<'static, Result<Option<AbsoluteBlockHeight>, postgres::Error>>
+            + Send
+            + Sync,
+    >,
+    on_use_node:
+        Box<dyn Fn(&mut v2::Client) -> BoxFuture<'static, Result<(), NodeError>> + Send + Sync>,
+    on_finalized_block: Box<
+        dyn Fn(&mut v2::Client, &FinalizedBlockInfo) -> BoxFuture<'static, Result<D, NodeError>>
+            + Send
+            + Sync,
+    >,
+}
+
+impl<D, P> Indexer<D, P>
+where
+    P: PrepareStatements + Send,
+    D: Send,
+{
+    pub async fn run(&'static self, app: SharedIndexerArgs) -> anyhow::Result<()> {
+        anyhow::ensure!(!app.endpoint.is_empty(), "At least one node must be provided.");
+        let config = app.config;
+
+        let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
+        // only log the current module (main).
+        log_builder.filter_module(module_path!(), app.log_level); // TODO: correct module?
+        log_builder.init();
+
+        // This program is set up as follows.
+        // It uses tokio to manage tasks. The reason for this is that it is the
+        // expectation that the main bottleneck is IO, either writing to the database or
+        // waiting for responses from the node.
+        // A background task is spawned whose only purpose is to write to the database.
+        // That task only terminates if the connection to the database is lost and
+        // cannot be established within half a minute or so (duration is governed by
+        // MAX_CONNECT_ATTEMPTS and exponential backoff).
+        //
+        // In the main task we query the nodes for block summaries. If querying the node
+        // fails, or the node is deemed too behind then we try the next node. The given
+        // nodes are tried in sequence and cycled when the end of the sequence is
+        // reached.
+        //
+        // The main task and the database writer task communicate via a bounded channel,
+        // with the main task sending block info and block summaries to the database
+        // writer thread.
+
+        // Since the database connection is managed by the background task we use a
+        // oneshot channel to get the height we should start querying at. First the
+        // background database task is started which then sends the height over this
+        // channel.
+        let (height_sender, height_receiver) = tokio::sync::oneshot::channel();
+        // Create a channel between the task querying the node and the task logging
+        // transactions.
+        let (sender, receiver) = tokio::sync::mpsc::channel(100);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+
+        let shutdown_handler_handle = tokio::spawn(set_shutdown(stop_flag.clone()));
+
+        let db_write_handle =
+            tokio::spawn(self.write_to_db(config, height_sender, receiver, stop_flag.clone()));
+        // The height we should start querying the node at.
+        // If the sender died we simply terminate the program.
+        let mut height = height_receiver.await?;
+
+        // To make sure we do not end up in an infinite loop in case all reconnects fail
+        // we count reconnects. We deem a node connection successful if it increases
+        // maximum achieved height by at least 1.
+        let mut max_height = height;
+        let mut last_success = 0;
+        let num_nodes = app.endpoint.len() as u64;
+        for (node_ep, idx) in app.endpoint.into_iter().cycle().zip(0u64..) {
+            if stop_flag.load(Ordering::Acquire) {
+                break;
+            }
+            if idx.saturating_sub(last_success) >= num_nodes {
+                // we skipped all the nodes without success.
+                let delay = std::time::Duration::from_secs(5);
+                log::error!(
+                    "Connections to all nodes have failed. Pausing for {}s before trying node {} \
+                     again.",
+                    delay.as_secs(),
+                    node_ep.uri()
+                );
+                tokio::time::sleep(delay).await;
+            }
+            // connect to the node.
+            log::info!("Attempting to use node {}", node_ep.uri());
+
+            let node_ep = node_ep
+                .connect_timeout(std::time::Duration::from_secs(app.connect_timeout.into()))
+                .timeout(std::time::Duration::from_secs(app.request_timeout.into()));
+
+            let node_result = self
+                .node_process(
+                    node_ep,
+                    &sender,
+                    &mut height,
+                    app.num_parallel,
+                    stop_flag.as_ref(),
+                    app.max_behind,
+                )
+                .await;
+
+            match node_result {
+                Err(NodeError::ConnectionError(e)) => {
+                    log::warn!(
+                        "Failed to connect to node due to {:#}. Will attempt another node.",
+                        e
+                    );
+                }
+                Err(NodeError::OtherError(e)) => {
+                    log::warn!("Node query failed due to: {:#}. Will attempt another node.", e);
+                }
+                Err(NodeError::NetworkError(e)) => {
+                    log::warn!(
+                        "Failed to connect to node due to {:#}. Will attempt another node.",
+                        e
+                    );
+                }
+                Err(NodeError::QueryError(e)) => {
+                    log::warn!(
+                        "Failed to connect to node due to {:#}. Will attempt another node.",
+                        e
+                    );
+                }
+                Err(NodeError::Timeout) => {
+                    log::warn!("Node too far behind. Will attempt another node.");
+                }
+                Ok(()) => break,
+            }
+            if height > max_height {
+                last_success = idx;
+                max_height = height;
+            }
+        }
+        db_write_handle.abort();
+        shutdown_handler_handle.abort();
+        Ok(())
+    }
+
+    /// Return Err if querying the node failed.
+    /// Return Ok(()) if the channel to the database was closed.
+    #[allow(clippy::too_many_arguments)]
+    async fn node_process(
+        &self,
+        node_ep: v2::Endpoint,
+        sender: &tokio::sync::mpsc::Sender<D>,
+        height: &mut AbsoluteBlockHeight, // start height
+        max_parallel: u32,
+        stop_flag: &AtomicBool,
+        max_behind: u32, /* maximum number of seconds a node can be behind before it is deemed
+                          * "behind" */
+    ) -> Result<(), NodeError> {
+        // Use TLS if the URI scheme is HTTPS.
+        // This uses whatever system certificates have been installed as trusted roots.
+        let node_ep = if node_ep.uri().scheme().map_or(false, |x| x == &http::uri::Scheme::HTTPS) {
+            node_ep.tls_config(ClientTlsConfig::new()).map_err(NodeError::ConnectionError)?
+        } else {
+            node_ep
+        };
+
+        let mut node = v2::Client::new(node_ep).await.map_err(NodeError::ConnectionError)?;
+        while !stop_flag.load(Ordering::Acquire) {
+            (self.on_use_node)(&mut node).await?;
+
+            let timeout = std::time::Duration::from_secs(max_behind.into());
+            let mut finalized_blocks = node.get_finalized_blocks_from(*height).await?;
+
+            let (has_error, chunks) = finalized_blocks
+                .next_chunk_timeout(max_parallel as usize, timeout)
+                .await
+                .map_err(|_| NodeError::Timeout)?;
+
+            for fb in chunks {
+                let d = (self.on_finalized_block)(&mut node, &fb).await?;
+
+                if sender.send(d).await.is_err() {
+                    log::error!(
+                        "The database connection has been closed. Terminating node queries."
+                    );
+                    return Ok(());
+                }
+
+                *height = height.next();
+            }
+
+            if has_error {
+                // we have processed the blocks we can, but further queries on the same stream
+                // will fail since the stream signalled an error.
+                return Err(NodeError::OtherError(anyhow::anyhow!(
+                    "Finalized block stream dropped."
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Try to reconnect to the database with exponential backoff, at most
+    /// MAX_CONNECT_ATTEMPTS times.
+    async fn try_reconnect(
+        &self,
+        config: &postgres::Config,
+        stop_flag: &AtomicBool,
+        create_tables: bool,
+    ) -> anyhow::Result<DBConn<P>> {
+        let mut i = 1;
+        let sql_opt: Option<&str> = if create_tables {
+            Some(&self.sql_schema)
+        } else {
+            None
+        };
+
+        while !stop_flag.load(Ordering::Acquire) {
+            match DBConn::create(config, sql_opt).await {
+                Ok(c) => return Ok(c),
+                Err(e) if i < MAX_CONNECT_ATTEMPTS => {
+                    let delay = std::time::Duration::from_millis(500 * (1 << i));
+                    log::error!(
+                        "Could not connect to the database due to {:#}. Reconnecting in {}ms",
+                        e,
+                        delay.as_millis()
+                    );
+                    // wait for 2^(i-1) seconds before attempting to reconnect.
+                    tokio::time::sleep(delay).await;
+                    i += 1;
+                }
+                Err(e) => {
+                    log::error!(
+                        "Could not connect to the database in {} attempts. Last attempt failed \
+                         with reason {:#}.",
+                        MAX_CONNECT_ATTEMPTS,
+                        e
+                    );
+                    return Err(e);
+                }
+            }
+        }
+        anyhow::bail!("The node was requested to stop.")
+    }
+
+    async fn write_to_db(
+        &self,
+        config: postgres::Config,
+        start_from_sender: tokio::sync::oneshot::Sender<AbsoluteBlockHeight>, // start height
+        mut receiver: tokio::sync::mpsc::Receiver<D>,
+        stop_flag: Arc<AtomicBool>,
+    ) -> anyhow::Result<()> {
+        let mut db = self.try_reconnect(&config, &stop_flag, true).await?;
+
+        let start_from =
+            (self.get_stored_max_height)(&db.client).await?.map_or(0.into(), |h| h.next());
+        start_from_sender
+            .send(start_from)
+            .map_err(|_| anyhow::anyhow!("Cannot send start height value to the node worker."))?;
+        let mut retry = None;
+        // How many successive insertion errors were encountered.
+        // This is used to slow down attempts to not spam the database
+        let mut successive_errors = 0;
+        while !stop_flag.load(Ordering::Acquire) {
+            let next_item = if let Some(v) = retry.take() {
+                Some(v)
+            } else {
+                receiver.recv().await
+            };
+            if let Some(data) = next_item {
+                match (self.insert_into_db)(&mut db).await {
+                    Ok(success) => {
+                        successive_errors = 0;
+                        log::info!(
+                            "Processed block {} at height {} in {}ms.",
+                            success.block_hash,
+                            success.block_height,
+                            success.time.num_milliseconds()
+                        );
+                    }
+                    Err(e) => {
+                        successive_errors += 1;
+                        // wait for 2^(min(successive_errors - 1, 7)) seconds before attempting.
+                        // The reason for the min is that we bound the time between reconnects.
+                        let delay = std::time::Duration::from_millis(
+                            500 * (1 << std::cmp::min(successive_errors, 8)),
+                        );
+                        log::error!(
+                            "Database connection lost due to {:#}. Will attempt to reconnect in \
+                             {}ms.",
+                            e,
+                            delay.as_millis()
+                        );
+                        tokio::time::sleep(delay).await;
+                        let new_db = match self.try_reconnect(&config, &stop_flag, false).await {
+                            Ok(db) => db,
+                            Err(e) => {
+                                receiver.close();
+                                return Err(e);
+                            }
+                        };
+                        // and drop the old database.
+                        let old_db = std::mem::replace(&mut db, new_db);
+                        match old_db.client.stop().await {
+                            Ok(v) => {
+                                if let Err(e) = v {
+                                    log::warn!(
+                                        "Could not correctly stop the old database connection due \
+                                         to: {}.",
+                                        e
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                if e.is_panic() {
+                                    log::warn!(
+                                        "Could not correctly stop the old database connection. \
+                                         The connection thread panicked."
+                                    );
+                                } else {
+                                    log::warn!(
+                                        "Could not correctly stop the old database connection."
+                                    );
+                                }
+                            }
+                        }
+                        retry = Some(data);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        // stop the database connection.
+        receiver.close();
+        db.client.stop().await??;
+        Ok(())
+    }
+}
+
+pub trait PrepareStatements {
+    fn prepare_all(client: &mut DatabaseClient) -> Self;
+}
+
+pub struct BlockInsertSuccess {
+    pub time:         chrono::Duration,
+    pub block_hash:   BlockHash,
+    pub block_height: AbsoluteBlockHeight,
+}
+
+/// A wrapper around a [`DatabaseClient`] that maintains prepared statements.
+pub struct DBConn<P> {
+    pub client:   DatabaseClient,
+    pub prepared: P,
+}
+
+impl<P: PrepareStatements> DBConn<P> {
+    /// Create a new database connection. If the second argument is `true` then
+    /// the table creation script will be run (see the file
+    /// `resources/schema.sql`). This script is in principle idempotent so
+    /// running it twice should be safe, but it is also needless,
+    /// so this should only be requested on a first connection on startup.
+    async fn create(config: &postgres::Config, try_run_sql: Option<&str>) -> anyhow::Result<Self> {
+        let mut client = DatabaseClient::create(config.clone(), postgres::NoTls).await?;
+
+        if let Some(sql) = try_run_sql {
+            client.as_ref().batch_execute(sql).await?
+        }
+
+        let prepared = P::prepare_all(&mut client);
+
+        Ok(Self {
+            client,
+            prepared,
+        })
+    }
+}
+///
+/// Construct a future for shutdown signals (for unix: SIGINT and SIGTERM) (for
+/// windows: ctrl c and ctrl break). The signal handler is set when the future
+/// is polled and until then the default signal handler.
+async fn set_shutdown(flag: Arc<AtomicBool>) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix as unix_signal;
+        let mut terminate_stream = unix_signal::signal(unix_signal::SignalKind::terminate())?;
+        let mut interrupt_stream = unix_signal::signal(unix_signal::SignalKind::interrupt())?;
+        let terminate = Box::pin(terminate_stream.recv());
+        let interrupt = Box::pin(interrupt_stream.recv());
+        futures::future::select(terminate, interrupt).await;
+        flag.store(true, Ordering::Release);
+    }
+    #[cfg(windows)]
+    {
+        use tokio::signal::windows as windows_signal;
+        let mut ctrl_break_stream = windows_signal::ctrl_break()?;
+        let mut ctrl_c_stream = windows_signal::ctrl_c()?;
+        let ctrl_break = Box::pin(ctrl_break_stream.recv());
+        let ctrl_c = Box::pin(ctrl_c_stream.recv());
+        futures::future::select(ctrl_break, ctrl_c).await;
+        flag.store(true, Ordering::Release);
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,8 @@ pub async fn set_shutdown(
     shutdown_sender.send("terminate".to_string())?;
     Ok(())
 }
-
+/// Handles database related execution, using `H` for domain-specific database
+/// queries. Will attempt to reconnect to database on errors.
 async fn use_db<D, P, H>(
     db: &mut DBConn<P>,
     db_factory: &mut DBConnFactory,
@@ -323,9 +324,9 @@ where
     }
 }
 
-/// Handles database related execution, using `H` for domain-specific database
-/// queries. Will attempt to reconnect to database on errors. Runs until
-/// `shutdown_receiver` receives any message.
+/// Runs process handling db related execution, constructing database
+/// connections using supplied configuration. Runs until `shutdown_receiver`
+/// receives any message.
 async fn db_process<D, P, H>(
     pg_config: postgres::Config,
     sql_schema: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,6 +439,7 @@ pub async fn run_service<D, P, DH, NH>(
     sql_schema: &'static str,
     app_config: SharedIndexerArgs,
     mut node_hooks: NH,
+    config_logger: Option<impl FnOnce(&mut env_logger::Builder, log::LevelFilter)>,
 ) -> Result<(), anyhow::Error>
 where
     P: PrepareStatements + Send + 'static,
@@ -450,8 +451,10 @@ where
     let config = app_config.config;
 
     let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
-    // only log the current module (main).
-    log_builder.filter_module(module_path!(), app_config.log_level); // TODO: correct module?
+    log_builder.filter_module(module_path!(), app_config.log_level);
+    if let Some(config_logger) = config_logger {
+        config_logger(&mut log_builder, app_config.log_level);
+    }
     log_builder.init();
 
     // This program is set up as follows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub async fn set_shutdown(
 
 /// Handles database related execution, using `H` for domain-specific database
 /// queries. Will attempt to reconnect to database on errors. Runs until
-/// `stop_flag` is triggered.
+/// `shutdown_receiver` receives any message.
 async fn write_to_db<D, P, H>(
     pg_config: postgres::Config,
     sql_schema: &'static str,
@@ -404,7 +404,7 @@ where
 
 /// Executes service infrastructure. Handles connections to a set of nodes and a
 /// database (configured with `app_config`) on their
-/// own separate threads.
+/// own separate threads. Runs until `shutdown_receiver` receives any message.
 /// Implementation of `NH` defines hooks used by the node thread, while
 /// implementation of `DH` defines hooks used by the database thread.
 pub async fn run_service<D, P, DH, NH>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,17 @@ pub struct BlockInsertSuccess {
     pub block_height: AbsoluteBlockHeight,
 }
 
+/// A collection of possible errors that can happen while using the database.
+#[derive(Debug, Error)]
+pub enum DatabaseError {
+    /// Database error.
+    #[error("Error using the database {0}.")]
+    PostgresError(#[from] postgres::Error),
+    /// Other errors while processing database data.
+    #[error("Error using the database {0}.")]
+    OtherError(#[from] anyhow::Error),
+}
+
 /// Defines a set of necessary callbacks used by the database thread.
 #[async_trait]
 pub trait DatabaseHooks<D, P> {
@@ -149,12 +160,12 @@ pub trait DatabaseHooks<D, P> {
     async fn insert_into_db(
         db_conn: &mut DBConn<P>,
         data: &D,
-    ) -> Result<BlockInsertSuccess, postgres::Error>;
+    ) -> Result<BlockInsertSuccess, DatabaseError>;
 
     /// Invoked by the database thread to request the latest recorded height in the database.
     async fn on_request_max_height(
         db: &DatabaseClient,
-    ) -> Result<Option<AbsoluteBlockHeight>, postgres::Error>;
+    ) -> Result<Option<AbsoluteBlockHeight>, DatabaseError>;
 }
 
 /// A collection of possible errors that can happen while using the node to query data.

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,14 +41,14 @@ pub enum BorrowedDatabaseSummaryEntry<'a> {
 
 pub struct SummaryRow<'a> {
     /// Hash of the block the row applies to.
-    pub block_hash: BlockHash,
+    pub block_hash:   BlockHash,
     /// Slot time of the block the row applies to.
-    pub block_time: Timestamp,
+    pub block_time:   Timestamp,
     /// Block height stored in the database.
     pub block_height: AbsoluteBlockHeight,
     /// Summary of the item. Either a user-generated transaction, or a protocol
     /// event that affected the account or contract.
-    pub summary: BorrowedDatabaseSummaryEntry<'a>,
+    pub summary:      BorrowedDatabaseSummaryEntry<'a>,
 }
 
 #[repr(transparent)]
@@ -56,9 +56,7 @@ pub struct SummaryRow<'a> {
 struct AccountAddressEq(AccountAddress);
 
 impl From<AccountAddressEq> for AccountAddress {
-    fn from(aae: AccountAddressEq) -> Self {
-        aae.0
-    }
+    fn from(aae: AccountAddressEq) -> Self { aae.0 }
 }
 
 impl PartialEq for AccountAddressEq {
@@ -77,13 +75,11 @@ impl Hash for AccountAddressEq {
 }
 
 impl AsRef<AccountAddressEq> for AccountAddress {
-    fn as_ref(&self) -> &AccountAddressEq {
-        unsafe { std::mem::transmute(self) }
-    }
+    fn as_ref(&self) -> &AccountAddressEq { unsafe { std::mem::transmute(self) } }
 }
 
 struct BlockItemSummaryWithCanonicalAddresses {
-    pub(crate) summary: BlockItemSummary,
+    pub(crate) summary:   BlockItemSummary,
     /// Affected addresses, resolved to canonical addresses and without
     /// duplicates.
     pub(crate) addresses: Vec<AccountAddress>,
@@ -98,11 +94,11 @@ type TransactionLogData =
 /// per-connection so we have to re-create them each time we reconnect.
 struct PreparedStatements {
     /// Insert into the summary table.
-    insert_summary: tokio_postgres::Statement,
+    insert_summary:             tokio_postgres::Statement,
     /// Insert into the account transaction index table.
-    insert_ati: tokio_postgres::Statement,
+    insert_ati:                 tokio_postgres::Statement,
     /// Insert into the contract transaction index table.
-    insert_cti: tokio_postgres::Statement,
+    insert_cti:                 tokio_postgres::Statement,
     /// Increase the total supply of a given token.
     cis2_increase_total_supply: tokio_postgres::Statement,
     /// Decrease the total supply of a given token.
@@ -360,8 +356,8 @@ impl PreparedStatements {
     }
 }
 
-/// Insert block into the database. Inserts transactionally by block to facilitate easy recovery if
-/// database connection is lost.
+/// Insert block into the database. Inserts transactionally by block to
+/// facilitate easy recovery if database connection is lost.
 async fn insert_block(
     db: &mut DBConn,
     block_hash: BlockHash,
@@ -522,7 +518,8 @@ impl NodeHooks<TransactionLogData> for NodeDelegate {
             .try_collect()
             .await?;
 
-        // Map account addresses affected by each summary to their respective canonical address
+        // Map account addresses affected by each summary to their respective canonical
+        // address
         let mut with_addresses = Vec::with_capacity(transaction_summaries.len());
         for summary in transaction_summaries {
             let affected_addresses = summary.affected_addresses();

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,16 +496,16 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Option<Vec<(ContractAddress, Vec<ci
     }
 }
 
-/// Handles database-related execution delegated from service infrastructure.
-struct DatabaseDelegate;
+/// Empty struct used for implementing [`DatabaseHooks`].
+struct DatabaseState;
 
 #[async_trait]
-impl DatabaseHooks<TransactionLogData, PreparedStatements> for DatabaseDelegate {
+impl DatabaseHooks<TransactionLogData, PreparedStatements> for DatabaseState {
     async fn insert_into_db(
         db_conn: &mut DBConn,
         (bi, item_summaries, special_events): &TransactionLogData,
     ) -> Result<BlockInsertSuccess, DatabaseError> {
-        let time = insert_block(
+        let duration = insert_block(
             db_conn,
             bi.block_hash,
             (bi.block_slot_time.timestamp_millis() as u64).into(),
@@ -516,7 +516,7 @@ impl DatabaseHooks<TransactionLogData, PreparedStatements> for DatabaseDelegate 
         .await?;
 
         Ok(BlockInsertSuccess {
-            time,
+            duration,
             block_height: bi.block_height,
             block_hash: bi.block_hash,
         })
@@ -530,15 +530,14 @@ impl DatabaseHooks<TransactionLogData, PreparedStatements> for DatabaseDelegate 
     }
 }
 
-/// Handles node-related execution delegated from service infrastructure.
-struct NodeDelegate {
-    canonical_cache: HashSet<AccountAddressEq>,
-}
+/// Holds a set of canonical account addresses already discovered while
+/// traversing the chain
+struct CanonicalAddressCache(HashSet<AccountAddressEq>);
 
 #[async_trait]
-impl NodeHooks<TransactionLogData> for NodeDelegate {
+impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
     async fn on_use_node(&mut self, client: &mut v2::Client) -> Result<(), NodeError> {
-        if self.canonical_cache.is_empty() {
+        if self.0.is_empty() {
             let accounts_response = client
                 .get_account_list(&v2::BlockIdentifier::LastFinal)
                 .await
@@ -551,7 +550,7 @@ impl NodeHooks<TransactionLogData> for NodeDelegate {
                 })
                 .await?;
 
-            self.canonical_cache = accounts;
+            self.0 = accounts;
         }
 
         Ok(())
@@ -591,7 +590,7 @@ impl NodeHooks<TransactionLogData> for NodeDelegate {
             // which is only possible to resolve by querying the node.
             let mut seen = HashSet::with_capacity(affected_addresses.len());
             for address in affected_addresses.into_iter() {
-                if let Some(addr) = self.canonical_cache.get(address.as_ref()) {
+                if let Some(addr) = self.0.get(address.as_ref()) {
                     let addr = AccountAddress::from(*addr);
                     if seen.insert(addr) {
                         addresses.push(addr);
@@ -606,7 +605,7 @@ impl NodeHooks<TransactionLogData> for NodeDelegate {
                     if seen.insert(addr) {
                         log::debug!("Discovered new address {}", addr);
                         addresses.push(addr);
-                        self.canonical_cache.insert(AccountAddressEq(addr));
+                        self.0.insert(AccountAddressEq(addr));
                     } else {
                         log::debug!("Canonical address {} already listed.", addr);
                     }
@@ -636,14 +635,11 @@ async fn main() -> anyhow::Result<()> {
     log_builder.filter_module(module_path!(), args.log_level);
     log_builder.init();
 
-    let (shutdown_send, shutdown_receive) = tokio::sync::watch::channel("init".to_string());
-
+    let (shutdown_send, shutdown_receive) = tokio::sync::watch::channel(());
     let shutdown_handler_handle = tokio::spawn(set_shutdown(shutdown_send));
 
     let sql_schema = include_str!("../resources/schema.sql");
-    let node_hooks = NodeDelegate {
-        canonical_cache: HashSet::new(),
-    };
+    let node_hooks = CanonicalAddressCache(HashSet::new());
 
     let run_service_args = SharedIndexerArgs {
         max_connect_attemps: MAX_CONNECT_ATTEMPTS,
@@ -655,7 +651,7 @@ async fn main() -> anyhow::Result<()> {
         endpoint:            args.endpoint,
     };
 
-    run_service::<TransactionLogData, PreparedStatements, DatabaseDelegate, NodeDelegate>(
+    run_service::<TransactionLogData, PreparedStatements, DatabaseState, CanonicalAddressCache>(
         sql_schema,
         run_service_args,
         shutdown_receive,
@@ -664,6 +660,5 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     shutdown_handler_handle.abort();
-
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,83 +10,22 @@ use concordium_rust_sdk::{
         hashes::BlockHash, queries::BlockInfo, AbsoluteBlockHeight, BlockItemSummary,
         ContractAddress, SpecialTransactionOutcome,
     },
-    v2,
+    v2::{self, FinalizedBlockInfo},
 };
-use futures::{StreamExt, TryStreamExt};
-use std::{
-    collections::HashSet,
-    convert::TryFrom,
-    hash::Hash,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use futures::TryStreamExt;
+use std::{collections::HashSet, convert::TryFrom, hash::Hash};
 use structopt::StructOpt;
-use thiserror::Error;
 use tokio_postgres::{
     types::{Json, ToSql},
     Transaction as DBTransaction,
 };
-use tonic::transport::ClientTlsConfig;
+use tonic::async_trait;
+use transaction_logger::{
+    run_service, BlockInsertSuccess, DatabaseHooks, NodeError, NodeHooks, PrepareStatements,
+    SharedIndexerArgs,
+};
 
-#[derive(StructOpt)]
-struct App {
-    #[structopt(
-        long = "node",
-        help = "GRPC interface of the node(s).",
-        default_value = "http://localhost:20000",
-        use_delimiter = true,
-        env = "TRANSACTION_LOGGER_NODES"
-    )]
-    endpoint:        Vec<v2::Endpoint>,
-    #[structopt(
-        long = "db",
-        default_value = "host=localhost dbname=transaction-outcome user=postgres \
-                         password=password port=5432",
-        help = "Database connection string.",
-        env = "TRANSACTION_LOGGER_DB_STRING"
-    )]
-    config:          postgres::Config,
-    #[structopt(
-        long = "log-level",
-        default_value = "off",
-        help = "Maximum log level.",
-        env = "TRANSACTION_LOGGER_LOG_LEVEL"
-    )]
-    log_level:       log::LevelFilter,
-    #[structopt(
-        long = "num-parallel",
-        default_value = "1",
-        help = "Maximum number of parallel queries to make to the node. Usually 1 is the correct \
-                number, but during initial catchup it is useful to increase this to, say 8 to \
-                take advantage of parallelism in queries.",
-        env = "TRANSACTION_LOGGER_NUM_PARALLEL_QUERIES"
-    )]
-    num_parallel:    u32,
-    #[structopt(
-        long = "max-behind-seconds",
-        default_value = "240",
-        help = "Maximum number of seconds the node's last finalization can be behind before the \
-                node is given up and another one is tried.",
-        env = "TRANSACTION_LOGGER_MAX_BEHIND_SECONDS"
-    )]
-    max_behind:      u32,
-    #[structopt(
-        long = "connect-timeout",
-        default_value = "10",
-        help = "Connection timeout for connecting to the node, in seconds",
-        env = "TRANSACTION_LOGGER_CONNECT_TIMEOUT"
-    )]
-    connect_timeout: u32,
-    #[structopt(
-        long = "request-timeout",
-        default_value = "60",
-        help = "Request timeout for node requests, in seconds",
-        env = "TRANSACTION_LOGGER_REQUEST_TIMEOUT"
-    )]
-    request_timeout: u32,
-}
+type DBConn = transaction_logger::DBConn<PreparedStatements>;
 
 #[derive(SerdeSerialize, Debug)]
 pub enum BorrowedDatabaseSummaryEntry<'a> {
@@ -102,18 +41,18 @@ pub enum BorrowedDatabaseSummaryEntry<'a> {
 
 pub struct SummaryRow<'a> {
     /// Hash of the block the row applies to.
-    pub block_hash:   BlockHash,
+    pub block_hash: BlockHash,
     /// Slot time of the block the row applies to.
-    pub block_time:   Timestamp,
+    pub block_time: Timestamp,
     /// Block height stored in the database.
     pub block_height: AbsoluteBlockHeight,
     /// Summary of the item. Either a user-generated transaction, or a protocol
     /// event that affected the account or contract.
-    pub summary:      BorrowedDatabaseSummaryEntry<'a>,
+    pub summary: BorrowedDatabaseSummaryEntry<'a>,
 }
 
 struct BlockItemSummaryWithCanonicalAddresses {
-    pub(crate) summary:   BlockItemSummary,
+    pub(crate) summary: BlockItemSummary,
     /// Affected addresses, resolved to canonical addresses and without
     /// duplicates.
     pub(crate) addresses: Vec<AccountAddress>,
@@ -123,37 +62,20 @@ struct BlockItemSummaryWithCanonicalAddresses {
 /// per-connection so we have to re-create them each time we reconnect.
 struct PreparedStatements {
     /// Insert into the summary table.
-    insert_summary:             tokio_postgres::Statement,
+    insert_summary: tokio_postgres::Statement,
     /// Insert into the account transaction index table.
-    insert_ati:                 tokio_postgres::Statement,
+    insert_ati: tokio_postgres::Statement,
     /// Insert into the contract transaction index table.
-    insert_cti:                 tokio_postgres::Statement,
+    insert_cti: tokio_postgres::Statement,
     /// Increase the total supply of a given token.
     cis2_increase_total_supply: tokio_postgres::Statement,
     /// Decrease the total supply of a given token.
     cis2_decrease_total_supply: tokio_postgres::Statement,
 }
 
-/// A wrapper around a [`DatabaseClient`] that maintains prepared statements.
-struct DBConn {
-    client:   DatabaseClient,
-    prepared: PreparedStatements,
-}
-
-impl DBConn {
-    /// Create a new database connection. If the second argument is `true` then
-    /// the table creation script will be run (see the file
-    /// `resources/schema.sql`). This script is in principle idempotent so
-    /// running it twice should be safe, but it is also needless,
-    /// so this should only be requested on a first connection on startup.
-    async fn create(config: &postgres::Config, try_create_tables: bool) -> anyhow::Result<Self> {
-        let mut client = DatabaseClient::create(config.clone(), postgres::NoTls).await?;
-
-        if try_create_tables {
-            let create = include_str!("../resources/schema.sql");
-            client.as_ref().batch_execute(create).await?
-        }
-
+#[async_trait]
+impl PrepareStatements for PreparedStatements {
+    async fn prepare_all(client: &mut DatabaseClient) -> Result<Self, postgres::Error> {
         let insert_ati =
             client.as_mut().prepare("INSERT INTO ati (account, summary) VALUES ($1, $2)").await?;
         let insert_cti = client
@@ -187,16 +109,14 @@ DO UPDATE SET total_supply = cis2_tokens.total_supply - EXCLUDED.total_supply
 RETURNING id",
             )
             .await?;
-        Ok(Self {
-            client,
-            prepared: PreparedStatements {
-                insert_summary,
-                insert_ati,
-                insert_cti,
-                cis2_increase_total_supply,
-                cis2_decrease_total_supply,
-            },
-        })
+
+        return Ok(Self {
+            insert_summary,
+            insert_ati,
+            insert_cti,
+            cis2_increase_total_supply,
+            cis2_decrease_total_supply,
+        });
     }
 }
 
@@ -404,14 +324,6 @@ impl PreparedStatements {
     }
 }
 
-impl AsRef<DatabaseClient> for DBConn {
-    fn as_ref(&self) -> &DatabaseClient { &self.client }
-}
-
-impl AsMut<DatabaseClient> for DBConn {
-    fn as_mut(&mut self) -> &mut DatabaseClient { &mut self.client }
-}
-
 async fn insert_block(
     db: &mut DBConn,
     block_hash: BlockHash,
@@ -450,8 +362,6 @@ async fn get_last_block_height(
     }
 }
 
-const MAX_CONNECT_ATTEMPTS: u64 = 6;
-
 /// Data sent by the node query task to the transaction insertion task.
 /// Contains all the information needed to build the transaction index.
 type TransactionLogData =
@@ -462,7 +372,9 @@ type TransactionLogData =
 struct AccountAddressEq(AccountAddress);
 
 impl From<AccountAddressEq> for AccountAddress {
-    fn from(aae: AccountAddressEq) -> Self { aae.0 }
+    fn from(aae: AccountAddressEq) -> Self {
+        aae.0
+    }
 }
 
 impl PartialEq for AccountAddressEq {
@@ -481,186 +393,133 @@ impl Hash for AccountAddressEq {
 }
 
 impl AsRef<AccountAddressEq> for AccountAddress {
-    fn as_ref(&self) -> &AccountAddressEq { unsafe { std::mem::transmute(self) } }
-}
-
-#[derive(Debug, Error)]
-enum NodeError {
-    /// Error establishing connection.
-    #[error("Error connecting to the node {0}.")]
-    ConnectionError(tonic::transport::Error),
-    /// No finalization in some time.
-    #[error("Timeout.")]
-    Timeout,
-    /// Error establishing connection.
-    #[error("Error during query {0}.")]
-    NetworkError(#[from] v2::Status),
-    /// Query error.
-    #[error("Error querying the node {0}.")]
-    QueryError(#[from] v2::QueryError),
-    /// Query errors, etc.
-    #[error("Error querying the node {0}.")]
-    OtherError(#[from] anyhow::Error),
+    fn as_ref(&self) -> &AccountAddressEq {
+        unsafe { std::mem::transmute(self) }
+    }
 }
 
 /// Return Err if querying the node failed.
 /// Return Ok(()) if the channel to the database was closed.
-#[allow(clippy::too_many_arguments)]
-async fn use_node(
-    node_ep: v2::Endpoint,
-    sender: &tokio::sync::mpsc::Sender<TransactionLogData>,
-    height: &mut AbsoluteBlockHeight, // start height
-    max_parallel: u32,
-    stop_flag: &AtomicBool,
-    canonical_cache: &mut HashSet<AccountAddressEq>,
-    max_behind: u32, // maximum number of seconds a node can be behind before it is deemed "behind"
-) -> Result<(), NodeError> {
-    // Use TLS if the URI scheme is HTTPS.
-    // This uses whatever system certificates have been installed as trusted roots.
-    let node_ep = if node_ep.uri().scheme().map_or(false, |x| x == &http::uri::Scheme::HTTPS) {
-        node_ep.tls_config(ClientTlsConfig::new()).map_err(NodeError::ConnectionError)?
-    } else {
-        node_ep
-    };
+// #[allow(clippy::too_many_arguments)]
+// async fn use_node(
+//     node_ep: v2::Endpoint,
+//     sender: &tokio::sync::mpsc::Sender<TransactionLogData>,
+//     height: &mut AbsoluteBlockHeight, // start height
+//     max_parallel: u32,
+//     stop_flag: &AtomicBool,
+//     canonical_cache: &mut HashSet<AccountAddressEq>,
+//     max_behind: u32, // maximum number of seconds a node can be behind before it is deemed "behind"
+// ) -> Result<(), NodeError> {
+//     // Use TLS if the URI scheme is HTTPS.
+//     // This uses whatever system certificates have been installed as trusted roots.
+//     let node_ep = if node_ep.uri().scheme().map_or(false, |x| x == &http::uri::Scheme::HTTPS) {
+//         node_ep.tls_config(ClientTlsConfig::new()).map_err(NodeError::ConnectionError)?
+//     } else {
+//         node_ep
+//     };
 
-    let mut node = v2::Client::new(node_ep).await.map_err(NodeError::ConnectionError)?;
-    // if the cache is empty we seed it with all accounts at the last finalized
-    // block. This will only happen the first time this function is successfully
-    // invoked.
-    if canonical_cache.is_empty() {
-        let accounts_response = node
-            .get_account_list(&v2::BlockIdentifier::LastFinal)
-            .await
-            .context("Error querying account list.")?;
-        let accounts = accounts_response.response;
-        let r = accounts
-            .try_fold(HashSet::new(), |mut cc, addr| async move {
-                let _ = cc.insert(AccountAddressEq(addr));
-                Ok(cc)
-            })
-            .await?;
-        *canonical_cache = r;
-    }
-    let mut finalized_blocks = node.get_finalized_blocks_from(*height).await?;
-    let timeout = std::time::Duration::from_secs(max_behind.into());
-    while !stop_flag.load(Ordering::Acquire) {
-        let (error, chunk) = finalized_blocks
-            .next_chunk_timeout(max_parallel as usize, timeout)
-            .await
-            .map_err(|_| NodeError::Timeout)?;
-        let mut futures = futures::stream::FuturesOrdered::new();
-        for fb in chunk {
-            let mut node = node.clone();
-            futures.push_back(async move {
-                let binfo = node.get_block_info(fb.block_hash).await?;
-                let events = if binfo.response.transaction_count == 0 {
-                    Vec::new()
-                } else {
-                    node.get_block_transaction_events(fb.block_hash)
-                        .await?
-                        .response
-                        .try_collect()
-                        .await?
-                };
-                let special = node
-                    .get_block_special_events(fb.block_hash)
-                    .await?
-                    .response
-                    .try_collect()
-                    .await?;
-                Ok::<
-                    (BlockInfo, Vec<BlockItemSummary>, Vec<SpecialTransactionOutcome>),
-                    anyhow::Error,
-                >((binfo.response, events, special))
-            });
-        }
-        while let Some(result) = futures.next().await {
-            let (binfo, transaction_summaries, special_events) = result?;
-            let mut with_addresses = Vec::with_capacity(transaction_summaries.len());
-            for summary in transaction_summaries {
-                let affected_addresses = summary.affected_addresses();
-                let mut addresses = Vec::with_capacity(affected_addresses.len());
-                // resolve canonical addresses. This part is only needed because the index
-                // is currently expected by "canonical address",
-                // which is only possible to resolve by querying the node.
-                let mut seen = HashSet::with_capacity(affected_addresses.len());
-                for address in affected_addresses.into_iter() {
-                    if let Some(addr) = canonical_cache.get(address.as_ref()) {
-                        let addr = AccountAddress::from(*addr);
-                        if seen.insert(addr) {
-                            addresses.push(addr);
-                        }
-                    } else {
-                        let ainfo = node
-                            .get_account_info(&address.into(), binfo.block_hash)
-                            .await
-                            .context("Error querying account info.")?
-                            .response;
-                        let addr = ainfo.account_address;
-                        if seen.insert(addr) {
-                            log::debug!("Discovered new address {}", addr);
-                            addresses.push(addr);
-                            canonical_cache.insert(AccountAddressEq(addr));
-                        } else {
-                            log::debug!("Canonical address {} already listed.", addr);
-                        }
-                    }
-                }
-                with_addresses.push(BlockItemSummaryWithCanonicalAddresses {
-                    summary,
-                    addresses,
-                })
-            }
-            if sender.send((binfo, with_addresses, special_events)).await.is_err() {
-                log::error!("The database connection has been closed. Terminating node queries.");
-                return Ok(());
-            }
-            *height = height.next();
-        }
-        if error {
-            // we have processed the blocks we can, but further queries on the same stream
-            // will fail since the stream signalled an error.
-            return Err(NodeError::OtherError(anyhow::anyhow!("Finalized block stream dropped.")));
-        }
-    }
-    Ok(())
-}
-
-/// Try to reconnect to the database with exponential backoff, at most
-/// MAX_CONNECT_ATTEMPTS times.
-async fn try_reconnect(
-    config: &postgres::Config,
-    stop_flag: &AtomicBool,
-    create_tables: bool,
-) -> anyhow::Result<DBConn> {
-    let mut i = 1;
-    while !stop_flag.load(Ordering::Acquire) {
-        match DBConn::create(config, create_tables).await {
-            Ok(c) => return Ok(c),
-            Err(e) if i < MAX_CONNECT_ATTEMPTS => {
-                let delay = std::time::Duration::from_millis(500 * (1 << i));
-                log::error!(
-                    "Could not connect to the database due to {:#}. Reconnecting in {}ms",
-                    e,
-                    delay.as_millis()
-                );
-                // wait for 2^(i-1) seconds before attempting to reconnect.
-                tokio::time::sleep(delay).await;
-                i += 1;
-            }
-            Err(e) => {
-                log::error!(
-                    "Could not connect to the database in {} attempts. Last attempt failed with \
-                     reason {:#}.",
-                    MAX_CONNECT_ATTEMPTS,
-                    e
-                );
-                return Err(e);
-            }
-        }
-    }
-    anyhow::bail!("The node was requested to stop.")
-}
+//     let mut node = v2::Client::new(node_ep).await.map_err(NodeError::ConnectionError)?;
+//     // if the cache is empty we seed it with all accounts at the last finalized
+//     // block. This will only happen the first time this function is successfully
+//     // invoked.
+//     if canonical_cache.is_empty() {
+//         let accounts_response = node
+//             .get_account_list(&v2::BlockIdentifier::LastFinal)
+//             .await
+//             .context("Error querying account list.")?;
+//         let accounts = accounts_response.response;
+//         let r = accounts
+//             .try_fold(HashSet::new(), |mut cc, addr| async move {
+//                 let _ = cc.insert(AccountAddressEq(addr));
+//                 Ok(cc)
+//             })
+//             .await?;
+//         *canonical_cache = r;
+//     }
+//     let mut finalized_blocks = node.get_finalized_blocks_from(*height).await?;
+//     let timeout = std::time::Duration::from_secs(max_behind.into());
+//     while !stop_flag.load(Ordering::Acquire) {
+//         let (error, chunk) = finalized_blocks
+//             .next_chunk_timeout(max_parallel as usize, timeout)
+//             .await
+//             .map_err(|_| NodeError::Timeout)?;
+//         let mut futures = futures::stream::FuturesOrdered::new();
+//         for fb in chunk {
+//             let mut node = node.clone();
+//             futures.push_back(async move {
+//                 let binfo = node.get_block_info(fb.block_hash).await?;
+//                 let events = if binfo.response.transaction_count == 0 {
+//                     Vec::new()
+//                 } else {
+//                     node.get_block_transaction_events(fb.block_hash)
+//                         .await?
+//                         .response
+//                         .try_collect()
+//                         .await?
+//                 };
+//                 let special = node
+//                     .get_block_special_events(fb.block_hash)
+//                     .await?
+//                     .response
+//                     .try_collect()
+//                     .await?;
+//                 Ok::<
+//                     (BlockInfo, Vec<BlockItemSummary>, Vec<SpecialTransactionOutcome>),
+//                     anyhow::Error,
+//                 >((binfo.response, events, special))
+//             });
+//         }
+//         while let Some(result) = futures.next().await {
+//             let (binfo, transaction_summaries, special_events) = result?;
+//             let mut with_addresses = Vec::with_capacity(transaction_summaries.len());
+//             for summary in transaction_summaries {
+//                 let affected_addresses = summary.affected_addresses();
+//                 let mut addresses = Vec::with_capacity(affected_addresses.len());
+//                 // resolve canonical addresses. This part is only needed because the index
+//                 // is currently expected by "canonical address",
+//                 // which is only possible to resolve by querying the node.
+//                 let mut seen = HashSet::with_capacity(affected_addresses.len());
+//                 for address in affected_addresses.into_iter() {
+//                     if let Some(addr) = canonical_cache.get(address.as_ref()) {
+//                         let addr = AccountAddress::from(*addr);
+//                         if seen.insert(addr) {
+//                             addresses.push(addr);
+//                         }
+//                     } else {
+//                         let ainfo = node
+//                             .get_account_info(&address.into(), binfo.block_hash)
+//                             .await
+//                             .context("Error querying account info.")?
+//                             .response;
+//                         let addr = ainfo.account_address;
+//                         if seen.insert(addr) {
+//                             log::debug!("Discovered new address {}", addr);
+//                             addresses.push(addr);
+//                             canonical_cache.insert(AccountAddressEq(addr));
+//                         } else {
+//                             log::debug!("Canonical address {} already listed.", addr);
+//                         }
+//                     }
+//                 }
+//                 with_addresses.push(BlockItemSummaryWithCanonicalAddresses {
+//                     summary,
+//                     addresses,
+//                 })
+//             }
+//             if sender.send((binfo, with_addresses, special_events)).await.is_err() {
+//                 log::error!("The database connection has been closed. Terminating node queries.");
+//                 return Ok(());
+//             }
+//             *height = height.next();
+//         }
+//         if error {
+//             // we have processed the blocks we can, but further queries on the same stream
+//             // will fail since the stream signalled an error.
+//             return Err(NodeError::OtherError(anyhow::anyhow!("Finalized block stream dropped.")));
+//         }
+//     }
+//     Ok(())
+// }
 
 /// Attempt to extract CIS2 events from the block item.
 /// If the transaction is a smart contract init or update transaction then
@@ -699,252 +558,218 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Option<Vec<(ContractAddress, Vec<ci
     }
 }
 
-async fn write_to_db(
-    config: postgres::Config,
-    height_sender: tokio::sync::oneshot::Sender<AbsoluteBlockHeight>, // start height
-    mut receiver: tokio::sync::mpsc::Receiver<TransactionLogData>,
-    stop_flag: Arc<AtomicBool>,
-) -> anyhow::Result<()> {
-    let mut db = try_reconnect(&config, &stop_flag, true).await?;
+struct DatabaseDelegate;
 
-    let height = get_last_block_height(&db.client).await?.map_or(0.into(), |h| h.next());
-    height_sender
-        .send(height)
-        .map_err(|_| anyhow::anyhow!("Cannot send height to the node worker."))?;
-    let mut retry = None;
-    // How many successive insertion errors were encountered.
-    // This is used to slow down attempts to not spam the database
-    let mut successive_errors = 0;
-    while !stop_flag.load(Ordering::Acquire) {
-        let next_item = if let Some(v) = retry.take() {
-            Some(v)
-        } else {
-            receiver.recv().await
-        };
-        if let Some((bi, item_summaries, special_events)) = next_item {
-            match insert_block(
-                &mut db,
-                bi.block_hash,
-                (bi.block_slot_time.timestamp_millis() as u64).into(),
-                bi.block_height,
-                &item_summaries,
-                &special_events,
-            )
-            .await
-            {
-                Ok(time) => {
-                    successive_errors = 0;
-                    log::info!(
-                        "Processed block {} at height {} in {}ms.",
-                        bi.block_hash,
-                        bi.block_height,
-                        time.num_milliseconds()
-                    );
-                }
-                Err(e) => {
-                    successive_errors += 1;
-                    // wait for 2^(min(successive_errors - 1, 7)) seconds before attempting.
-                    // The reason for the min is that we bound the time between reconnects.
-                    let delay = std::time::Duration::from_millis(
-                        500 * (1 << std::cmp::min(successive_errors, 8)),
-                    );
-                    log::error!(
-                        "Database connection lost due to {:#}. Will attempt to reconnect in {}ms.",
-                        e,
-                        delay.as_millis()
-                    );
-                    tokio::time::sleep(delay).await;
-                    let new_db = match try_reconnect(&config, &stop_flag, false).await {
-                        Ok(db) => db,
-                        Err(e) => {
-                            receiver.close();
-                            return Err(e);
-                        }
-                    };
-                    // and drop the old database.
-                    let old_db = std::mem::replace(&mut db, new_db);
-                    match old_db.client.stop().await {
-                        Ok(v) => {
-                            if let Err(e) = v {
-                                log::warn!(
-                                    "Could not correctly stop the old database connection due to: \
-                                     {}.",
-                                    e
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            if e.is_panic() {
-                                log::warn!(
-                                    "Could not correctly stop the old database connection. The \
-                                     connection thread panicked."
-                                );
-                            } else {
-                                log::warn!("Could not correctly stop the old database connection.");
-                            }
-                        }
-                    }
-                    retry = Some((bi, item_summaries, special_events));
-                }
-            }
-        } else {
-            break;
-        }
+#[async_trait]
+impl DatabaseHooks<TransactionLogData, PreparedStatements> for DatabaseDelegate {
+    async fn insert_into_db(
+        db_conn: &mut DBConn,
+        (bi, item_summaries, special_events): &TransactionLogData,
+    ) -> Result<BlockInsertSuccess, postgres::Error> {
+        let res = insert_block(
+            db_conn,
+            bi.block_hash,
+            (bi.block_slot_time.timestamp_millis() as u64).into(),
+            bi.block_height,
+            item_summaries,
+            special_events,
+        )
+        .await;
+
+        res.map(|time| BlockInsertSuccess {
+            time,
+            block_height: bi.block_height,
+            block_hash: bi.block_hash,
+        })
     }
-    // stop the database connection.
-    receiver.close();
-    db.client.stop().await??;
-    Ok(())
+
+    async fn on_request_max_height(
+        db: &DatabaseClient,
+    ) -> Result<Option<AbsoluteBlockHeight>, postgres::Error> {
+        get_last_block_height(db).await
+    }
 }
 
-/// Construct a future for shutdown signals (for unix: SIGINT and SIGTERM) (for
-/// windows: ctrl c and ctrl break). The signal handler is set when the future
-/// is polled and until then the default signal handler.
-async fn set_shutdown(flag: Arc<AtomicBool>) -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        use tokio::signal::unix as unix_signal;
-        let mut terminate_stream = unix_signal::signal(unix_signal::SignalKind::terminate())?;
-        let mut interrupt_stream = unix_signal::signal(unix_signal::SignalKind::interrupt())?;
-        let terminate = Box::pin(terminate_stream.recv());
-        let interrupt = Box::pin(interrupt_stream.recv());
-        futures::future::select(terminate, interrupt).await;
-        flag.store(true, Ordering::Release);
+struct NodeDelegate {
+    canonical_cache: HashSet<AccountAddressEq>,
+}
+
+#[async_trait]
+impl NodeHooks<TransactionLogData> for NodeDelegate {
+    async fn on_use_node(&mut self, client: &mut v2::Client) -> Result<(), NodeError> {
+        if self.canonical_cache.is_empty() {
+            let accounts_response = client
+                .get_account_list(&v2::BlockIdentifier::LastFinal)
+                .await
+                .context("Error querying account list.")?;
+            let accounts = accounts_response.response;
+            let accounts = accounts
+                .try_fold(HashSet::new(), |mut cc, addr| async move {
+                    let _ = cc.insert(AccountAddressEq(addr));
+                    Ok(cc)
+                })
+                .await?;
+
+            self.canonical_cache = accounts;
+        }
+
+        Ok(())
     }
-    #[cfg(windows)]
-    {
-        use tokio::signal::windows as windows_signal;
-        let mut ctrl_break_stream = windows_signal::ctrl_break()?;
-        let mut ctrl_c_stream = windows_signal::ctrl_c()?;
-        let ctrl_break = Box::pin(ctrl_break_stream.recv());
-        let ctrl_c = Box::pin(ctrl_c_stream.recv());
-        futures::future::select(ctrl_break, ctrl_c).await;
-        flag.store(true, Ordering::Release);
+
+    async fn on_finalized_block(
+        &mut self,
+        client: &mut v2::Client,
+        finalized_block_info: &FinalizedBlockInfo,
+    ) -> Result<TransactionLogData, NodeError> {
+        todo!()
     }
-    Ok(())
 }
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     let app = {
-        let app = App::clap()
+        let app = SharedIndexerArgs::clap()
             // .setting(AppSettings::ArgRequiredElseHelp)
             .global_setting(AppSettings::ColoredHelp);
         let matches = app.get_matches();
-        App::from_clap(&matches)
+        SharedIndexerArgs::from_clap(&matches)
     };
     anyhow::ensure!(!app.endpoint.is_empty(), "At least one node must be provided.");
-    let config = app.config;
 
-    let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
-    // only log the current module (main).
-    log_builder.filter_module(module_path!(), app.log_level);
-    log_builder.init();
+    let sql_schema = include_str!("../resources/schema.sql");
+    let node_hooks = NodeDelegate {
+        canonical_cache: HashSet::new(),
+    };
 
-    // This program is set up as follows.
-    // It uses tokio to manage tasks. The reason for this is that it is the
-    // expectation that the main bottleneck is IO, either writing to the database or
-    // waiting for responses from the node.
-    // A background task is spawned whose only purpose is to write to the database.
-    // That task only terminates if the connection to the database is lost and
-    // cannot be established within half a minute or so (duration is governed by
-    // MAX_CONNECT_ATTEMPTS and exponential backoff).
-    //
-    // In the main task we query the nodes for block summaries. If querying the node
-    // fails, or the node is deemed too behind then we try the next node. The given
-    // nodes are tried in sequence and cycled when the end of the sequence is
-    // reached.
-    //
-    // The main task and the database writer task communicate via a bounded channel,
-    // with the main task sending block info and block summaries to the database
-    // writer thread.
+    run_service::<TransactionLogData, PreparedStatements, DatabaseDelegate, NodeDelegate>(
+        sql_schema, app, node_hooks,
+    )
+    .await?;
 
-    // Since the database connection is managed by the background task we use a
-    // oneshot channel to get the height we should start querying at. First the
-    // background database task is started which then sends the height over this
-    // channel.
-    let (height_sender, height_receiver) = tokio::sync::oneshot::channel();
-    // Create a channel between the task querying the node and the task logging
-    // transactions.
-    let (sender, receiver) = tokio::sync::mpsc::channel(100);
-
-    let stop_flag = Arc::new(AtomicBool::new(false));
-
-    let shutdown_handler_handle = tokio::spawn(set_shutdown(stop_flag.clone()));
-
-    let db_write_handle =
-        tokio::spawn(write_to_db(config, height_sender, receiver, stop_flag.clone()));
-    // The height we should start querying the node at.
-    // If the sender died we simply terminate the program.
-    let mut height = height_receiver.await?;
-
-    // Cache where we store the mapping from account aliases to canonical account
-    // addresses. This is done by storing just equivalence classes represented
-    // by the canonical address.
-    let mut canonical_cache = HashSet::new();
-    // To make sure we do not end up in an infinite loop in case all reconnects fail
-    // we count reconnects. We deem a node connection successful if it increases
-    // maximum achieved height by at least 1.
-    let mut max_height = height;
-    let mut last_success = 0;
-    let num_nodes = app.endpoint.len() as u64;
-    for (node_ep, idx) in app.endpoint.into_iter().cycle().zip(0u64..) {
-        if stop_flag.load(Ordering::Acquire) {
-            break;
-        }
-        if idx.saturating_sub(last_success) >= num_nodes {
-            // we skipped all the nodes without success.
-            let delay = std::time::Duration::from_secs(5);
-            log::error!(
-                "Connections to all nodes have failed. Pausing for {}s before trying node {} \
-                 again.",
-                delay.as_secs(),
-                node_ep.uri()
-            );
-            tokio::time::sleep(delay).await;
-        }
-        // connect to the node.
-        log::info!("Attempting to use node {}", node_ep.uri());
-
-        let node_ep = node_ep
-            .connect_timeout(std::time::Duration::from_secs(app.connect_timeout.into()))
-            .timeout(std::time::Duration::from_secs(app.request_timeout.into()));
-
-        let node_result = use_node(
-            node_ep,
-            &sender,
-            &mut height,
-            app.num_parallel,
-            stop_flag.as_ref(),
-            &mut canonical_cache,
-            app.max_behind,
-        )
-        .await;
-
-        match node_result {
-            Err(NodeError::ConnectionError(e)) => {
-                log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
-            }
-            Err(NodeError::OtherError(e)) => {
-                log::warn!("Node query failed due to: {:#}. Will attempt another node.", e);
-            }
-            Err(NodeError::NetworkError(e)) => {
-                log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
-            }
-            Err(NodeError::QueryError(e)) => {
-                log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
-            }
-            Err(NodeError::Timeout) => {
-                log::warn!("Node too far behind. Will attempt another node.");
-            }
-            Ok(()) => break,
-        }
-        if height > max_height {
-            last_success = idx;
-            max_height = height;
-        }
-    }
-    db_write_handle.abort();
-    shutdown_handler_handle.abort();
     Ok(())
 }
+
+// #[tokio::main(flavor = "multi_thread")]
+// async fn main() -> anyhow::Result<()> {
+//     let app = {
+//         let app = SharedIndexerArgs::clap()
+//             // .setting(AppSettings::ArgRequiredElseHelp)
+//             .global_setting(AppSettings::ColoredHelp);
+//         let matches = app.get_matches();
+//         SharedIndexerArgs::from_clap(&matches)
+//     };
+//     anyhow::ensure!(!app.endpoint.is_empty(), "At least one node must be provided.");
+//     let config = app.config;
+
+//     let mut log_builder = env_logger::Builder::from_env("TRANSACTION_LOGGER_LOG");
+//     // only log the current module (main).
+//     log_builder.filter_module(module_path!(), app.log_level);
+//     log_builder.init();
+
+//     // This program is set up as follows.
+//     // It uses tokio to manage tasks. The reason for this is that it is the
+//     // expectation that the main bottleneck is IO, either writing to the database or
+//     // waiting for responses from the node.
+//     // A background task is spawned whose only purpose is to write to the database.
+//     // That task only terminates if the connection to the database is lost and
+//     // cannot be established within half a minute or so (duration is governed by
+//     // MAX_CONNECT_ATTEMPTS and exponential backoff).
+//     //
+//     // In the main task we query the nodes for block summaries. If querying the node
+//     // fails, or the node is deemed too behind then we try the next node. The given
+//     // nodes are tried in sequence and cycled when the end of the sequence is
+//     // reached.
+//     //
+//     // The main task and the database writer task communicate via a bounded channel,
+//     // with the main task sending block info and block summaries to the database
+//     // writer thread.
+
+//     // Since the database connection is managed by the background task we use a
+//     // oneshot channel to get the height we should start querying at. First the
+//     // background database task is started which then sends the height over this
+//     // channel.
+//     let (height_sender, height_receiver) = tokio::sync::oneshot::channel();
+//     // Create a channel between the task querying the node and the task logging
+//     // transactions.
+//     let (sender, receiver) = tokio::sync::mpsc::channel(100);
+
+//     let stop_flag = Arc::new(AtomicBool::new(false));
+
+//     let shutdown_handler_handle = tokio::spawn(set_shutdown(stop_flag.clone()));
+
+//     let db_write_handle =
+//         tokio::spawn(write_to_db(config, height_sender, receiver, stop_flag.clone()));
+//     // The height we should start querying the node at.
+//     // If the sender died we simply terminate the program.
+//     let mut height = height_receiver.await?;
+
+//     // Cache where we store the mapping from account aliases to canonical account
+//     // addresses. This is done by storing just equivalence classes represented
+//     // by the canonical address.
+//     let mut canonical_cache = HashSet::new();
+//     // To make sure we do not end up in an infinite loop in case all reconnects fail
+//     // we count reconnects. We deem a node connection successful if it increases
+//     // maximum achieved height by at least 1.
+//     let mut max_height = height;
+//     let mut last_success = 0;
+//     let num_nodes = app.endpoint.len() as u64;
+//     for (node_ep, idx) in app.endpoint.into_iter().cycle().zip(0u64..) {
+//         if stop_flag.load(Ordering::Acquire) {
+//             break;
+//         }
+//         if idx.saturating_sub(last_success) >= num_nodes {
+//             // we skipped all the nodes without success.
+//             let delay = std::time::Duration::from_secs(5);
+//             log::error!(
+//                 "Connections to all nodes have failed. Pausing for {}s before trying node {} \
+//                  again.",
+//                 delay.as_secs(),
+//                 node_ep.uri()
+//             );
+//             tokio::time::sleep(delay).await;
+//         }
+//         // connect to the node.
+//         log::info!("Attempting to use node {}", node_ep.uri());
+
+//         let node_ep = node_ep
+//             .connect_timeout(std::time::Duration::from_secs(app.connect_timeout.into()))
+//             .timeout(std::time::Duration::from_secs(app.request_timeout.into()));
+
+//         let node_result = use_node(
+//             node_ep,
+//             &sender,
+//             &mut height,
+//             app.num_parallel,
+//             stop_flag.as_ref(),
+//             &mut canonical_cache,
+//             app.max_behind,
+//         )
+//         .await;
+
+//         match node_result {
+//             Err(NodeError::ConnectionError(e)) => {
+//                 log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
+//             }
+//             Err(NodeError::OtherError(e)) => {
+//                 log::warn!("Node query failed due to: {:#}. Will attempt another node.", e);
+//             }
+//             Err(NodeError::NetworkError(e)) => {
+//                 log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
+//             }
+//             Err(NodeError::QueryError(e)) => {
+//                 log::warn!("Failed to connect to node due to {:#}. Will attempt another node.", e);
+//             }
+//             Err(NodeError::Timeout) => {
+//                 log::warn!("Node too far behind. Will attempt another node.");
+//             }
+//             Ok(()) => break,
+//         }
+//         if height > max_height {
+//             last_success = idx;
+//             max_height = height;
+//         }
+//     }
+//     db_write_handle.abort();
+//     shutdown_handler_handle.abort();
+//     Ok(())
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,6 +438,7 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Option<Vec<(ContractAddress, Vec<ci
     }
 }
 
+/// Handles database-related execution delegated from service infrastructure.
 struct DatabaseDelegate;
 
 #[async_trait]
@@ -471,6 +472,7 @@ impl DatabaseHooks<TransactionLogData, PreparedStatements> for DatabaseDelegate 
     }
 }
 
+/// Handles node-related execution delegated from service infrastructure.
 struct NodeDelegate {
     canonical_cache: HashSet<AccountAddressEq>,
 }
@@ -575,9 +577,15 @@ async fn main() -> anyhow::Result<()> {
     let node_hooks = NodeDelegate {
         canonical_cache: HashSet::new(),
     };
+    let config_logger = |builder: &mut env_logger::Builder, log_level: log::LevelFilter| {
+        builder.filter_module(module_path!(), log_level);
+    };
 
     run_service::<TransactionLogData, PreparedStatements, DatabaseDelegate, NodeDelegate>(
-        sql_schema, app, node_hooks,
+        sql_schema,
+        app,
+        node_hooks,
+        Some(config_logger),
     )
     .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ type DBConn = transaction_logger::DBConn<PreparedStatements>;
 
 const MAX_CONNECT_ATTEMPTS: u32 = 6;
 
-/// A collection on arguments necessary to run the service. These are supplied via the command
-/// line.
+/// A collection on arguments necessary to run the service. These are supplied
+/// via the command line.
 #[derive(StructOpt)]
 struct Args {
     #[structopt(
@@ -40,7 +40,7 @@ struct Args {
         use_delimiter = true,
         env = "TRANSACTION_LOGGER_NODES"
     )]
-    endpoint: Vec<v2::Endpoint>,
+    endpoint:        Vec<v2::Endpoint>,
     #[structopt(
         long = "db",
         default_value = "host=localhost dbname=transaction-outcome user=postgres \
@@ -48,14 +48,14 @@ struct Args {
         help = "Database connection string.",
         env = "TRANSACTION_LOGGER_DB_STRING"
     )]
-    config: postgres::Config,
+    config:          postgres::Config,
     #[structopt(
         long = "log-level",
         default_value = "off",
         help = "Maximum log level.",
         env = "TRANSACTION_LOGGER_LOG_LEVEL"
     )]
-    log_level: log::LevelFilter,
+    log_level:       log::LevelFilter,
     #[structopt(
         long = "num-parallel",
         default_value = "1",
@@ -64,7 +64,7 @@ struct Args {
                 take advantage of parallelism in queries.",
         env = "TRANSACTION_LOGGER_NUM_PARALLEL_QUERIES"
     )]
-    num_parallel: u32,
+    num_parallel:    u32,
     #[structopt(
         long = "max-behind-seconds",
         default_value = "240",
@@ -72,7 +72,7 @@ struct Args {
                 node is given up and another one is tried.",
         env = "TRANSACTION_LOGGER_MAX_BEHIND_SECONDS"
     )]
-    max_behind: u32,
+    max_behind:      u32,
     #[structopt(
         long = "connect-timeout",
         default_value = "10",
@@ -103,14 +103,14 @@ pub enum BorrowedDatabaseSummaryEntry<'a> {
 
 pub struct SummaryRow<'a> {
     /// Hash of the block the row applies to.
-    pub block_hash: BlockHash,
+    pub block_hash:   BlockHash,
     /// Slot time of the block the row applies to.
-    pub block_time: Timestamp,
+    pub block_time:   Timestamp,
     /// Block height stored in the database.
     pub block_height: AbsoluteBlockHeight,
     /// Summary of the item. Either a user-generated transaction, or a protocol
     /// event that affected the account or contract.
-    pub summary: BorrowedDatabaseSummaryEntry<'a>,
+    pub summary:      BorrowedDatabaseSummaryEntry<'a>,
 }
 
 #[repr(transparent)]
@@ -118,9 +118,7 @@ pub struct SummaryRow<'a> {
 struct AccountAddressEq(AccountAddress);
 
 impl From<AccountAddressEq> for AccountAddress {
-    fn from(aae: AccountAddressEq) -> Self {
-        aae.0
-    }
+    fn from(aae: AccountAddressEq) -> Self { aae.0 }
 }
 
 impl PartialEq for AccountAddressEq {
@@ -139,13 +137,11 @@ impl Hash for AccountAddressEq {
 }
 
 impl AsRef<AccountAddressEq> for AccountAddress {
-    fn as_ref(&self) -> &AccountAddressEq {
-        unsafe { std::mem::transmute(self) }
-    }
+    fn as_ref(&self) -> &AccountAddressEq { unsafe { std::mem::transmute(self) } }
 }
 
 struct BlockItemSummaryWithCanonicalAddresses {
-    pub(crate) summary: BlockItemSummary,
+    pub(crate) summary:   BlockItemSummary,
     /// Affected addresses, resolved to canonical addresses and without
     /// duplicates.
     pub(crate) addresses: Vec<AccountAddress>,
@@ -160,11 +156,11 @@ type TransactionLogData =
 /// per-connection so we have to re-create them each time we reconnect.
 struct PreparedStatements {
     /// Insert into the summary table.
-    insert_summary: tokio_postgres::Statement,
+    insert_summary:             tokio_postgres::Statement,
     /// Insert into the account transaction index table.
-    insert_ati: tokio_postgres::Statement,
+    insert_ati:                 tokio_postgres::Statement,
     /// Insert into the contract transaction index table.
-    insert_cti: tokio_postgres::Statement,
+    insert_cti:                 tokio_postgres::Statement,
     /// Increase the total supply of a given token.
     cis2_increase_total_supply: tokio_postgres::Statement,
     /// Decrease the total supply of a given token.
@@ -647,12 +643,12 @@ async fn main() -> anyhow::Result<()> {
 
     let run_service_args = SharedIndexerArgs {
         max_connect_attemps: MAX_CONNECT_ATTEMPTS,
-        max_behind: args.max_behind,
-        num_parallel: args.num_parallel,
-        connect_timeout: args.connect_timeout,
-        request_timeout: args.request_timeout,
-        db_config: args.config,
-        endpoint: args.endpoint,
+        max_behind:          args.max_behind,
+        num_parallel:        args.num_parallel,
+        connect_timeout:     args.connect_timeout,
+        request_timeout:     args.request_timeout,
+        db_config:           args.config,
+        endpoint:            args.endpoint,
     };
 
     run_service::<TransactionLogData, PreparedStatements, DatabaseDelegate, NodeDelegate>(


### PR DESCRIPTION
## Purpose

In preparation of implementing #19, the parts pertaining to keeping an indexing service running have been extracted into `lib.rs` with the purpose of reusing them across similar services.

I'm not sure I'm satisfied with how the logger is built and initialised (specifically whether this should be the responsibility of `lib.rs` or each concrete service implementation), so some feedback on this would be very much appreciated, along with all other feedback of course 😉 

Closes #20 

## Changes

- Provide `run_service` entrypoint and the necessary traits in `lib.rs` to build custom indexing applications
- Implement `main.rs` through the use of `lib.rs`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
