### PR TITLE
Integrate postgres code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
-  RUST_CLIPPY: 1.65
+  RUST_CLIPPY: 1.73
 
 jobs:
   "lint_fmt":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Moved the postgres feature from the Rust SDK into this crate as its own code.
+- Updated the CI Rust version to 1.73
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Moved the postgres feature from the Rust SDK into this crate as its own code.
+
 ## 0.8.0
 
 - Add support for node version 6. This is a breaking change and this version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -67,6 +67,12 @@ checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -99,6 +105,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +247,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -134,7 +258,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -201,12 +325,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -233,15 +351,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -309,11 +418,12 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.9.9",
+ "sha2",
+ "tinyvec",
 ]
 
 [[package]]
@@ -367,9 +477,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -379,18 +492,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -420,15 +532,16 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.0.0"
+version = "9.1.0"
 dependencies = [
+ "base64",
  "bs58",
  "chrono",
  "concordium-contracts-common-derive",
  "fnv",
  "hashbrown 0.11.2",
  "hex",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "rust_decimal",
@@ -439,16 +552,16 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "3.0.0"
+version = "4.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -461,24 +574,25 @@ dependencies = [
  "hex",
  "http",
  "num",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-traits",
  "prost",
- "rand 0.7.3",
+ "rand",
  "rust_decimal",
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2",
  "thiserror",
  "tokio",
- "tokio-postgres",
+ "tokio-stream",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "2.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -489,10 +603,10 @@ dependencies = [
  "futures",
  "libc",
  "num_enum",
- "rand 0.8.5",
+ "rand",
  "secp256k1",
  "serde",
- "sha2 0.10.7",
+ "sha2",
  "sha3",
  "slab",
  "thiserror",
@@ -501,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "2.0.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -512,11 +626,16 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "2.0.0"
+version = "5.0.0"
 dependencies = [
  "aes",
  "anyhow",
- "base64 0.13.1",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "base64",
  "bs58",
  "byteorder",
  "cbc",
@@ -528,7 +647,6 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "ff",
- "group",
  "hex",
  "hmac",
  "itertools",
@@ -536,18 +654,16 @@ dependencies = [
  "libc",
  "nom",
  "num",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-traits",
- "pairing",
  "pbkdf2",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
  "rayon",
  "rust_decimal",
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.10.7",
+ "sha2",
  "sha3",
  "subtle",
  "thiserror",
@@ -560,8 +676,14 @@ version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.76",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -644,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -659,15 +781,31 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "group",
+ "rand_core",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -691,7 +829,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -702,7 +840,28 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -720,59 +879,54 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
+ "serde",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek",
- "hashbrown 0.12.3",
+ "ed25519",
+ "hashbrown 0.14.0",
  "hex",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -809,28 +963,20 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "ff"
-version = "0.5.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4530da57967e140ee0b44e0143aa66b5cb42bd9c503dbe316a15d5b0be65713e"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "byteorder",
- "ff_derive",
- "rand_core 0.5.1",
+ "bitvec",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
-name = "ff_derive"
-version = "0.4.1"
+name = "fiat-crypto"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5796e7d62ca01a00ed3a649b0da1ffa1ac8f06bcad40339df09dbdd69a05ba9"
-dependencies = [
- "num-bigint 0.2.6",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fnv"
@@ -900,7 +1046,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -945,24 +1091,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -977,13 +1112,13 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.2.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbdfc48f95bef47e3daf3b9d552a1dde6311e3a5fefa43e16c59f651d56fe5b"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.7.3",
- "rand_xorshift",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1034,6 +1169,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1074,7 +1213,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1260,9 +1399,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "lock_api"
@@ -1292,7 +1431,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1329,7 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -1349,22 +1488,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -1416,7 +1544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1442,23 +1570,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1480,18 +1608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "pairing"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c40534479a28199cd5109da27fe2fc4a4728e4fc701d9e9c1bded78f3271e4"
-dependencies = [
- "byteorder",
- "ff",
- "group",
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,7 +1627,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1521,9 +1637,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -1531,10 +1653,10 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hmac",
  "password-hash",
- "sha2 0.10.7",
+ "sha2",
 ]
 
 [[package]]
@@ -1578,7 +1700,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1592,6 +1714,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "polyval"
@@ -1611,15 +1743,15 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
- "sha2 0.10.7",
+ "rand",
+ "sha2",
  "stringprep",
 ]
 
@@ -1687,18 +1819,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1706,15 +1838,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1739,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1754,37 +1886,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1794,16 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1812,34 +1911,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1908,10 +1980,25 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1954,7 +2041,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -1971,14 +2058,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.8",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -1999,7 +2086,17 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.2",
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2035,8 +2132,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -2094,31 +2191,32 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2129,14 +2227,14 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.22",
+ "time",
 ]
 
 [[package]]
@@ -2148,20 +2246,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2172,7 +2257,7 @@ checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2181,9 +2266,15 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2196,9 +2287,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "simdutf8"
@@ -2252,6 +2346,22 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stringprep"
@@ -2318,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2374,18 +2484,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2467,7 +2566,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2496,13 +2595,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -2558,17 +2656,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64",
  "bytes",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2577,18 +2673,16 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -2602,7 +2696,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -2643,7 +2737,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2653,16 +2747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2679,6 +2763,7 @@ dependencies = [
  "http",
  "log",
  "serde",
+ "serde_json",
  "structopt",
  "thiserror",
  "tokio",
@@ -2748,6 +2833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "uuid"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,18 +2867,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2813,7 +2892,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -2835,7 +2914,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2854,16 +2933,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2903,7 +2972,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2927,7 +2996,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2946,6 +3024,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,6 +3050,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2970,6 +3070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,6 +3086,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2994,6 +3112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,6 +3128,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3018,6 +3148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +3164,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3049,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -3064,5 +3206,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.76",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium-rust-sdk = { path = "./deps/concordium-rust-sdk", version = "*", features = ["postgres"] }
+concordium-rust-sdk = { path = "./deps/concordium-rust-sdk", version = "*" }
 anyhow = "1"
 tokio = {version = "1.8", features = ["full"]}
 thiserror = "1.0"
@@ -17,7 +17,8 @@ tokio-postgres = { version = "^0.7.7", features = ["with-serde_json-1"] }
 env_logger = "0.9"
 log = "0.4"
 http = "0.2"
-tonic = {version = "0.8", features = ["tls", "tls-roots"]} # Use system trust roots.
+tonic = { version = "0.10", features = ["tls", "tls-roots"] } # Use system trust roots.
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 async-trait = "0.1.68"
+serde_json = "1.0.127"

--- a/examples/monitor-postgres.rs
+++ b/examples/monitor-postgres.rs
@@ -1,0 +1,102 @@
+//! Monitor a given account for incoming transactions.
+//! This example uses a simple polling method to query account transactions in a
+//! postgres database.
+//!
+//! For accounts with less activity it is likely going to be better to make use
+//! of postgres notifications to avoid queries which will mostly return nothing.
+
+use clap::AppSettings;
+use concordium_rust_sdk::id::types::AccountAddress;
+use futures::StreamExt;
+use structopt::StructOpt;
+use tokio_postgres::NoTls;
+use transaction_logger::postgres::{DatabaseClient, QueryOrder};
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(long = "account")]
+    account:   AccountAddress,
+    #[structopt(
+        long = "db",
+        default_value = "host=localhost dbname=transaction-outcome user=postgres \
+                         password=password port=5432",
+        help = "Database connection string."
+    )]
+    config:    tokio_postgres::Config,
+    #[structopt(
+        long = "wait-time",
+        help = "Database polling interval in ms.",
+        default_value = "2000"
+    )]
+    wait_time: u32,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap()
+            // .setting(AppSettings::ArgRequiredElseHelp)
+            .global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let db = DatabaseClient::create(app.config, NoTls).await?;
+    let addr: AccountAddress = app.account;
+    // get the ID where new events will start at.
+    let start_id = {
+        let rows = db
+            .query_account(&addr, 1, QueryOrder::Descending {
+                start: None,
+            })
+            .await?;
+        rows.fold(0, |_, row| async move { row.id + 1 }).await
+    };
+
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(100);
+
+    let wait_time = std::time::Duration::from_millis(app.wait_time.into());
+
+    // Repeatedly poll for new data, and send it over.
+    let poller = async move {
+        let mut next_start_id = start_id;
+        loop {
+            let rows = db
+                .query_account(&addr, 100, QueryOrder::Ascending {
+                    start: Some(next_start_id),
+                })
+                .await?;
+            // in the fold closure below we only need a reference to the channel
+            // but we need to capture count and rows by value, so we need to use move
+            // the following line makes it so that the reference to the sender channel
+            // is moved, but we retain ownership of the channel.
+            let sender = &sender;
+            let (num_rows, new_start) = rows
+                .fold((0, start_id), |(count, _), row| async move {
+                    let new_start_id = row.id + 1;
+                    sender.send(row).await.unwrap();
+                    (count + 1, new_start_id)
+                })
+                .await;
+            if num_rows == 0 {
+                // If we did not get any rows don't query again for a bit.
+                tokio::time::sleep(wait_time).await
+            }
+            next_start_id = new_start;
+        }
+        // we only use the Ok to specify the return type of the async block
+        // But it is unreachable.
+        #[allow(unreachable_code)]
+        Ok::<(), tokio_postgres::Error>(())
+    };
+
+    let _handle = tokio::spawn(poller);
+
+    while let Some(row) = receiver.recv().await {
+        if row.summary.sender_account().as_ref() != Some(&addr) {
+            println!("Incoming transaction: {:?}", row)
+        }
+    }
+
+    Ok(())
+}

--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -1,0 +1,82 @@
+use clap::AppSettings;
+use concordium_rust_sdk::{id::types::AccountAddress, types::ContractAddress};
+use futures::StreamExt;
+use structopt::StructOpt;
+use tokio_postgres::NoTls;
+use transaction_logger::postgres::{DatabaseClient, QueryOrder};
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(long = "account")]
+    account: AccountAddress,
+    #[structopt(
+        long = "db",
+        default_value = "host=localhost dbname=transaction-outcome user=postgres \
+                         password=password port=5432",
+        help = "Database connection string."
+    )]
+    config:  tokio_postgres::Config,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap()
+            // .setting(AppSettings::ArgRequiredElseHelp)
+            .global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let config = app.config;
+
+    let db = DatabaseClient::create(config, NoTls).await?;
+    let addr: AccountAddress = app.account;
+    let rows = db
+        .query_account(&addr, 50, QueryOrder::Ascending {
+            start: None,
+        })
+        .await?;
+    rows.for_each(|entry| async move {
+        println!("{:?}", entry.id);
+    })
+    .await;
+
+    let rows = db
+        .query_contract(ContractAddress::new(0, 0), 20, QueryOrder::Ascending {
+            start: None,
+        })
+        .await?;
+    rows.for_each(|entry| async move {
+        println!("{:?}", entry);
+    })
+    .await;
+
+    let rows = db
+        .query_account(&addr, 20, QueryOrder::Descending {
+            start: None,
+        })
+        .await?;
+    rows.for_each(|entry| async move {
+        println!("{:?}", entry);
+    })
+    .await;
+
+    let rows = db
+        .query_contract(ContractAddress::new(0, 0), 20, QueryOrder::Descending {
+            start: None,
+        })
+        .await?;
+    rows.for_each(|entry| async move {
+        println!("{:?}", entry);
+    })
+    .await;
+
+    let rows = db.iterate_account(&addr, None).await?;
+    rows.for_each(|entry| async move {
+        println!("{:?}", entry.id);
+    })
+    .await;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,14 @@
+pub mod postgres;
+
 use anyhow::{anyhow, Context};
 use concordium_rust_sdk::{
-    postgres::{self, DatabaseClient},
     types::{hashes::BlockHash, AbsoluteBlockHeight},
     v2::{self, FinalizedBlockInfo},
 };
 use thiserror::Error;
 use tonic::{async_trait, transport::ClientTlsConfig};
+
+use postgres::DatabaseClient;
 
 /// A collection of variables supplied to [`run_service`]. These determine how
 /// the service runs with regards to connections to concordium node(s), db, and

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,6 @@ use concordium_rust_sdk::{
     cis2::{self, TokenAmount, TokenId},
     common::{types::Timestamp, SerdeSerialize},
     id::types::AccountAddress,
-    postgres,
-    postgres::DatabaseClient,
     types::{
         hashes::BlockHash, queries::BlockInfo, AbsoluteBlockHeight, BlockItemSummary,
         ContractAddress, SpecialTransactionOutcome,
@@ -21,6 +19,7 @@ use tokio_postgres::{
 };
 use tonic::async_trait;
 use transaction_logger::{
+    postgres::{self, DatabaseClient},
     run_service, set_shutdown, BlockInsertSuccess, DatabaseError, DatabaseHooks, NodeError,
     NodeHooks, PrepareStatements, SharedIndexerArgs,
 };

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,0 +1,367 @@
+use concordium_rust_sdk::{
+    base::hashes::BlockHash,
+    common::types::Timestamp,
+    id::types::AccountAddress,
+    types::{AbsoluteBlockHeight, BlockItemSummary, ContractAddress, SpecialTransactionOutcome},
+};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+use tokio::task::{JoinError, JoinHandle};
+use tokio_postgres::{
+    types::{BorrowToSql, ToSql},
+    RowStream,
+};
+pub use tokio_postgres::{Config, Error, NoTls};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum DatabaseSummaryEntry {
+    #[serde(rename = "Left")]
+    /// An item that is explicitly included in the block. This is always a
+    /// result of user actions, e.g., transfers, account creations.
+    BlockItem(BlockItemSummary),
+    #[serde(rename = "Right")]
+    /// Protocol generated event, such as baking and finalization rewards, and
+    /// minting.
+    ProtocolEvent(SpecialTransactionOutcome),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Row returned from the Postgres database, either from the
+/// account transaction index, or from the contract transaction index.
+/// Each row corresponds to one transaction that affected the given item
+/// (account or contract).
+pub struct DatabaseRow {
+    /// Internal id of the row. This can be used in repeated queries to get more
+    /// pages of results.
+    pub id:           i64,
+    /// Hash of the block the row applies to.
+    pub block_hash:   BlockHash,
+    /// Slot time of the block the row applies to.
+    pub block_time:   Timestamp,
+    /// Block height stored in the database.
+    pub block_height: AbsoluteBlockHeight,
+    /// Summary of the item. Either a user-generated transaction, or a protocol
+    /// event that affected the account or contract.
+    pub summary:      DatabaseSummaryEntry,
+}
+
+impl DatabaseSummaryEntry {
+    /// Get the sender account of the transaction. The sender account only
+    /// exists for normal transactions and does not exist for
+    /// - credential deployments that create accounts
+    /// - chain updates and special outcomes
+    pub fn sender_account(&self) -> Option<AccountAddress> {
+        match self {
+            DatabaseSummaryEntry::BlockItem(bi) => bi.sender_account(),
+            DatabaseSummaryEntry::ProtocolEvent(_) => None,
+        }
+    }
+}
+
+/// A helper to enable support both for prepared and raw statements.
+/// Prepared statements can be more efficient, but they require the database
+/// tables to already exist when establishing the database connection.
+enum QueryStatement {
+    Raw(&'static str),
+    Prepared(tokio_postgres::Statement),
+}
+
+struct QueryStatements {
+    /// Prepared statement that is used to query accounts in ascending order.
+    /// It has 3 placeholders, for account address, `id` start and limit.
+    query_account_statement_asc:   QueryStatement,
+    /// Prepared statement that is used to query contracts in ascending order.
+    /// It has 4 placeholders, for contract index and subindex, `id` start and
+    /// limit.
+    query_contract_statement_asc:  QueryStatement,
+    /// Prepared statement that is used to query contracts in descending order.
+    /// It has 3 placeholders, for account address, `id` start and limit.
+    query_account_statement_desc:  QueryStatement,
+    /// Prepared statement that is used to query contracts in descending order.
+    /// It has 4 placeholders, for contract index and subindex, `id` start and
+    /// limit.
+    query_contract_statement_desc: QueryStatement,
+}
+
+impl QueryStatements {
+    pub async fn create(
+        client: &tokio_postgres::Client,
+        prepared: bool,
+    ) -> Result<Self, tokio_postgres::Error> {
+        // NB before changing the queries.
+        // In these queries we add a semantically unnecessary ORDER BY
+        // summaries.id. This is added to increase performance of the queries.
+        // Otherwise queries with small limits take a lot more time (<0.5s vs 7s). The
+        // reason for this appears to be the postgresql query planner which chooses
+        // a wrong approach for small limits for the database we have.
+        let query_account_statement_asc = {
+            let statement = "SELECT ati.id, summaries.block, summaries.timestamp, \
+                             summaries.height, summaries.summary
+ FROM ati JOIN summaries ON ati.summary = summaries.id
+ WHERE ati.account = $1 AND ati.id >= $2
+ ORDER BY ati.id ASC, summaries.id ASC LIMIT $3";
+            if prepared {
+                QueryStatement::Prepared(client.prepare(statement).await?)
+            } else {
+                QueryStatement::Raw(statement)
+            }
+        };
+
+        let query_contract_statement_asc = {
+            let statement = "SELECT cti.id, summaries.block, summaries.timestamp, \
+                             summaries.height, summaries.summary
+ FROM cti JOIN summaries ON cti.summary = summaries.id
+ WHERE cti.index = $1 AND cti.subindex = $2 AND cti.id >= $3
+ ORDER BY cti.id ASC, summaries.id ASC LIMIT $4";
+            if prepared {
+                QueryStatement::Prepared(client.prepare(statement).await?)
+            } else {
+                QueryStatement::Raw(statement)
+            }
+        };
+
+        let query_account_statement_desc = {
+            let statement = "SELECT ati.id, summaries.block, summaries.timestamp, \
+                             summaries.height, summaries.summary
+ FROM ati JOIN summaries ON ati.summary = summaries.id
+ WHERE ati.account = $1 AND ati.id <= $2
+ ORDER BY ati.id DESC, summaries.id DESC LIMIT $3";
+            if prepared {
+                QueryStatement::Prepared(client.prepare(statement).await?)
+            } else {
+                QueryStatement::Raw(statement)
+            }
+        };
+
+        let query_contract_statement_desc = {
+            let statement = "SELECT cti.id, summaries.block, summaries.timestamp, \
+                             summaries.height, summaries.summary
+ FROM cti JOIN summaries ON cti.summary = summaries.id
+ WHERE cti.index = $1 AND cti.subindex = $2 AND cti.id <= $3
+ ORDER BY cti.id DESC, summaries.id DESC LIMIT $4";
+            if prepared {
+                QueryStatement::Prepared(client.prepare(statement).await?)
+            } else {
+                QueryStatement::Raw(statement)
+            }
+        };
+        Ok(Self {
+            query_account_statement_asc,
+            query_contract_statement_asc,
+            query_account_statement_desc,
+            query_contract_statement_desc,
+        })
+    }
+}
+
+/// The database client for interfacing with the Postgres database.
+/// Some common queries are provided as methods on this struct. If these do not
+/// provide enough flexibility then the `AsRef<tokio_postgres::Client>` trait
+/// implementation provides a way to use the database client to make queries
+/// directly on the underlying client.
+///
+/// The correct way to close the database connection is to call
+/// [DatabaseClient::stop]. This will make sure that the background connection
+/// task is correctly shut down.
+pub struct DatabaseClient {
+    /// Connection handle that can be used to drop the connection.
+    /// The connection is spawned in a background tokio task.
+    connection_handle: JoinHandle<Result<(), tokio_postgres::Error>>,
+    database_client:   tokio_postgres::Client,
+    statements:        QueryStatements,
+}
+
+impl DatabaseClient {
+    /// Close the connection to the database and drop the client.
+    pub async fn stop(self) -> Result<Result<(), tokio_postgres::Error>, JoinError> {
+        self.connection_handle.abort();
+        self.connection_handle.await
+    }
+}
+
+/// This implementation enables direct queries on the underlying database
+/// client.
+impl AsRef<tokio_postgres::Client> for DatabaseClient {
+    fn as_ref(&self) -> &tokio_postgres::Client { &self.database_client }
+}
+
+/// This implementation enables direct queries on the underlying database
+/// client such as [Client::transaction](https://docs.rs/tokio-postgres/*/tokio_postgres/struct.Client.html#method.transaction)
+/// that require mutable access to the underlying client
+impl AsMut<tokio_postgres::Client> for DatabaseClient {
+    fn as_mut(&mut self) -> &mut tokio_postgres::Client { &mut self.database_client }
+}
+
+impl DatabaseClient {
+    /// Create a connection to the database. This does not create any prepared
+    /// statements. If the database and its tables already exist prefer
+    /// [DatabaseClient::create_prepared], however if the database tables do not
+    /// yet exist then use this method to build it.
+    pub async fn create<T: tokio_postgres::tls::MakeTlsConnect<tokio_postgres::Socket>>(
+        config: tokio_postgres::Config,
+        tls: T,
+    ) -> Result<DatabaseClient, tokio_postgres::Error>
+    where
+        T::Stream: Send + 'static, {
+        let (database_client, connection) = config.connect(tls).await?;
+        let connection_handle = tokio::spawn(connection);
+        let statements = QueryStatements::create(&database_client, false).await?;
+        Ok(DatabaseClient {
+            connection_handle,
+            database_client,
+            statements,
+        })
+    }
+
+    /// Like [DatabaseClient::create] but creates prepared statements and thus
+    /// requires all the necessary database tables to already exist. Use this
+    /// when using the database in read-only mode.
+    pub async fn create_prepared<T: tokio_postgres::tls::MakeTlsConnect<tokio_postgres::Socket>>(
+        config: tokio_postgres::Config,
+        tls: T,
+    ) -> Result<DatabaseClient, tokio_postgres::Error>
+    where
+        T::Stream: Send + 'static, {
+        let (database_client, connection) = config.connect(tls).await?;
+        let connection_handle = tokio::spawn(connection);
+        let statements = QueryStatements::create(&database_client, true).await?;
+        Ok(DatabaseClient {
+            connection_handle,
+            database_client,
+            statements,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Return results in the given order.
+pub enum QueryOrder {
+    Ascending {
+        /// Return results where the row ID is `start` or higher.
+        /// If `start` is not given assume starting from the beginning.
+        start: Option<i64>,
+    },
+    Descending {
+        /// Return results where the row ID is `start` or lower.
+        /// If `start` is not given assume starting from the end.
+        start: Option<i64>,
+    },
+}
+
+impl DatabaseClient {
+    async fn query<P, I>(&self, st: &QueryStatement, params: I) -> Result<RowStream, Error>
+    where
+        P: BorrowToSql,
+        I: IntoIterator<Item = P>,
+        I::IntoIter: ExactSizeIterator, {
+        match st {
+            QueryStatement::Raw(r) => self.as_ref().query_raw(*r, params).await,
+            QueryStatement::Prepared(p) => self.as_ref().query_raw(p, params).await,
+        }
+    }
+
+    /// Get the list of transactions affecting the given account.
+    /// The return value is a stream of rows that have been parsed.
+    ///
+    /// The `limit` value limits the number of rows that will be returned.
+    pub async fn query_account<'a>(
+        &'a self,
+        acc: &'a AccountAddress,
+        limit: i64,
+        order: QueryOrder,
+    ) -> Result<impl futures::stream::Stream<Item = DatabaseRow>, tokio_postgres::Error> {
+        let (statement, start) = match order {
+            QueryOrder::Ascending {
+                start,
+            } => (&self.statements.query_account_statement_asc, start.unwrap_or(i64::MIN)),
+            QueryOrder::Descending {
+                start,
+            } => (&self.statements.query_account_statement_desc, start.unwrap_or(i64::MAX)),
+        };
+        let acc_raw: &[u8] = acc.as_ref();
+        let params = [
+            &acc_raw as &(dyn ToSql + Sync),
+            &start as &(dyn ToSql + Sync),
+            &limit as &(dyn ToSql + Sync),
+        ];
+
+        let rows = self.query(statement, params).await?;
+        Ok(rows.filter_map(|row_or_err| async move { construct_row(row_or_err) }))
+    }
+
+    /// Get the list of transactions affecting the given contract.
+    /// The return value is a stream of rows that have been parsed.
+    ///
+    /// The `limit` value limits the number of rows that will be returned.
+    pub async fn query_contract(
+        &self,
+        c: ContractAddress,
+        limit: i64,
+        order: QueryOrder,
+    ) -> Result<impl futures::stream::Stream<Item = DatabaseRow>, tokio_postgres::Error> {
+        let (statement, start) = match order {
+            QueryOrder::Ascending {
+                start,
+            } => (&self.statements.query_contract_statement_asc, start.unwrap_or(i64::MIN)),
+            QueryOrder::Descending {
+                start,
+            } => (&self.statements.query_contract_statement_desc, start.unwrap_or(i64::MAX)),
+        };
+
+        let params: [i64; 4] = [c.index as i64, c.subindex as i64, start, limit];
+
+        let rows = self.query(statement, &params).await?;
+        Ok(rows.filter_map(|row_or_err| async move { construct_row(row_or_err) }))
+    }
+
+    /// Return all transactions affecting the account, starting with the given
+    /// row id.
+    pub async fn iterate_account(
+        &self,
+        acc: &AccountAddress,
+        start: Option<i64>,
+    ) -> Result<impl futures::stream::Stream<Item = DatabaseRow>, tokio_postgres::Error> {
+        self.query_account(acc, i64::MAX, QueryOrder::Ascending {
+            start,
+        })
+        .await
+    }
+
+    /// Return all transactions affecting the contract, starting with the given
+    /// row id.
+    pub async fn iterate_contract(
+        &self,
+        addr: ContractAddress,
+        start: Option<i64>,
+    ) -> Result<impl futures::stream::Stream<Item = DatabaseRow>, tokio_postgres::Error> {
+        self.query_contract(addr, i64::MAX, QueryOrder::Ascending {
+            start,
+        })
+        .await
+    }
+}
+
+/// Try to parse a row returned from the database.
+/// This deliberately turns all errors into `None` since in the context it is
+/// used errors should not occur.
+fn construct_row(
+    row_or_error: Result<tokio_postgres::Row, tokio_postgres::Error>,
+) -> Option<DatabaseRow> {
+    let row = row_or_error.ok()?;
+    let id = row.get(0);
+    let hash_bytes: &[u8] = row.get(1);
+    let block_hash = BlockHash::new(hash_bytes.try_into().ok()?);
+    let block_time = Timestamp::from(row.get::<_, i64>(2) as u64);
+    let block_height = AbsoluteBlockHeight::from(row.get::<_, i64>(3) as u64);
+    let summary = serde_json::from_value::<DatabaseSummaryEntry>(row.get(4)).ok()?;
+    Some(DatabaseRow {
+        id,
+        block_hash,
+        block_time,
+        block_height,
+        summary,
+    })
+}


### PR DESCRIPTION
## Purpose

The postgres feature has been removed from the SDK, so this crate (which I suppose is the only user of that feature) needs to integrate this functionality into itself, rather than relying on the SDK for it.

## Changes

The postgres feature from the SDK was yanked out in https://github.com/Concordium/concordium-rust-sdk/pull/204 - this PR adds this functionality back into this crate. The examples are brought over as well. The code is otherwise unchanged.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.