### PR TITLE
COR-1794 Key update transaction watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+Database schema version: 2
+
+- added database migration to create `account_public_key_bindings` and inserts data for all account public key mappings into this table
+
 - Added `PublicKeyBindingInfo` type that represents public key info of accounts access structure.
 - Added `PublicKeyBindingInfo` into `TransactionLogData`.
 - Added `insert_key_bindings` and `delete_key_bindings` feilds into `PreparedStatements`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased changes
 
+- Added `PublicKeyBindingInfo` type that represents public key info of accounts access structure.
+- Added `PublicKeyBindingInfo` into `TransactionLogData`.
+- Added `insert_key_bindings` and `delete_key_bindings` feilds into `PreparedStatements`.
+- The DB task is extended to save account's address and public key binding.
+- The Node task is extended to monitor for public key update and new account creation transactions.
+
 ## [0.14.0] - 2025-08-07
 
 ### Changed

--- a/resources/m0002-accounts-public-key-bindings.sql
+++ b/resources/m0002-accounts-public-key-bindings.sql
@@ -1,0 +1,15 @@
+-- Table that stores the public keys associated with the account addresses
+CREATE TABLE IF NOT EXISTS account_public_key_bindings(
+    id BIGSERIAL PRIMARY KEY ,
+    -- The account address.
+    address BYTEA NOT NULL,
+    -- The public key.
+    public_key BYTEA NOT NULL,
+    -- The index of a public key by a credential.
+    credential_index INT NOT NULL,
+    key_index INT NOT NULL,
+    -- True if there is only one public key associated with a given account.
+    is_simple_account BOOLEAN NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_public_key_bindings_public_key ON account_public_key_bindings (public_key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,10 @@ impl DBConfiguration {
     }
 
     /// Create a [`DBConn`] connection, and run the database migration task.
-    async fn get_new_conn<P: PrepareStatements>(&mut self) -> anyhow::Result<DBConn<P>> {
+    async fn get_new_conn<P: PrepareStatements>(
+        &mut self,
+        endpoints: &[v2::Endpoint],
+    ) -> anyhow::Result<DBConn<P>> {
         let mut client = DatabaseClient::create(self.pg_config.clone(), postgres::NoTls).await?;
 
         let cancel_token = CancellationToken::new();
@@ -67,7 +70,7 @@ impl DBConfiguration {
         // remaining database migrations until the `SchemaVersion::LATEST` is
         // reached.
         let migration_task =
-            cancel_token.run_until_cancelled(migrations::run_migrations(&mut client));
+            cancel_token.run_until_cancelled(migrations::run_migrations(&mut client, endpoints));
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
                log::info!("Migrations aborted, shutting down");
@@ -96,11 +99,12 @@ impl DBConfiguration {
     async fn try_connect<P: PrepareStatements>(
         &mut self,
         max_connect_attemps: u32,
+        endpoints: &[v2::Endpoint],
     ) -> anyhow::Result<DBConn<P>> {
         let mut i = 1;
 
         loop {
-            match self.get_new_conn().await {
+            match self.get_new_conn(endpoints).await {
                 Ok(c) => return Ok(c),
                 Err(e) if i < max_connect_attemps => {
                     let delay = std::time::Duration::from_millis(500 * (1 << i));
@@ -252,6 +256,7 @@ async fn use_db<D, P, H>(
     start_from_sender: tokio::sync::oneshot::Sender<AbsoluteBlockHeight>, // start height
     mut receiver: tokio::sync::mpsc::Receiver<D>,
     max_connect_attemps: u32,
+    endpoints: &[v2::Endpoint],
 ) -> anyhow::Result<()>
 where
     P: PrepareStatements,
@@ -301,7 +306,7 @@ where
                         delay.as_millis()
                     );
                     tokio::time::sleep(delay).await;
-                    let new_db = match db_config.try_connect(max_connect_attemps).await {
+                    let new_db = match db_config.try_connect(max_connect_attemps, endpoints).await {
                         Ok(db) => db,
                         Err(e) => {
                             receiver.close();
@@ -349,6 +354,7 @@ async fn db_process<D, P, H>(
     receiver: tokio::sync::mpsc::Receiver<D>,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
     max_connect_attemps: u32,
+    endpoints: Vec<v2::Endpoint>,
 ) -> anyhow::Result<()>
 where
     P: PrepareStatements,
@@ -359,13 +365,13 @@ where
     let mut sr = shutdown_receiver.clone();
     let mut db = tokio::select! {
         _ = sr.changed() => anyhow::bail!("Service shut down manually"),
-        db_res = db_config.try_connect(max_connect_attemps) => db_res?
+        db_res = db_config.try_connect(max_connect_attemps, &endpoints) => db_res?
     };
 
     let mut sr = shutdown_receiver.clone();
     tokio::select! {
         _ = sr.changed() => (),
-        res = use_db::<D, P, H>(&mut db, &mut db_config, start_from_sender, receiver, max_connect_attemps) => res?
+        res = use_db::<D, P, H>(&mut db, &mut db_config, start_from_sender, receiver, max_connect_attemps, &endpoints) => res?
     };
 
     // stop the database connection.
@@ -482,13 +488,14 @@ where
     // Create a channel between the task querying the node and the task logging
     // transactions.
     let (sender, receiver) = tokio::sync::mpsc::channel(100);
-
+    let endpoints = app_config.endpoint.clone();
     let db_write_handle = tokio::spawn(db_process::<D, P, DH>(
         db_config,
         height_sender,
         receiver,
         shutdown_receiver.clone(),
         app_config.max_connect_attemps,
+        endpoints,
     ));
     // The height we should start querying the node at.
     // If the sender died we simply terminate the program.

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,7 +516,7 @@ impl PreparedStatements {
         tx: &DBTransaction<'_>,
         address: &[u8],
     ) -> Result<(), postgres::Error> {
-        tx.execute(&self.delete_key_bindings, &[&&address[..]])
+        tx.execute(&self.delete_key_bindings, &[&address])
             .await?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,8 +516,7 @@ impl PreparedStatements {
         tx: &DBTransaction<'_>,
         address: &[u8],
     ) -> Result<(), postgres::Error> {
-        tx.execute(&self.delete_key_bindings, &[&address])
-            .await?;
+        tx.execute(&self.delete_key_bindings, &[&address]).await?;
         Ok(())
     }
 }

--- a/src/migrations/m0002_acoount_public_key_binding.rs
+++ b/src/migrations/m0002_acoount_public_key_binding.rs
@@ -1,0 +1,172 @@
+use anyhow::Context;
+use concordium_rust_sdk::{
+    base::transactions::AccountAccessStructure,
+    common::Serial,
+    types::{AbsoluteBlockHeight, AccountInfo},
+    v2::{self, BlockIdentifier},
+};
+use futures::{stream, StreamExt, TryStreamExt};
+use tokio::time::Instant;
+use tokio_postgres::types::ToSql;
+use tokio_postgres::Transaction;
+
+/// Represents one pending insertion row for the `account_public_key_bindings` table to be inserted
+type PendingPublicKeyBindingInsertionRow = (Vec<u8>, Vec<u8>, i32, i32, bool);
+
+pub async fn run(tx: &mut Transaction<'_>, endpoints: &[v2::Endpoint]) -> anyhow::Result<()> {
+    println!("Starting migration now for public keys");
+
+    // Get time of the start of the migration - so that we can measure how long it takes
+    let start = Instant::now();
+
+    // create the table bindings table
+    let query = include_str!("../../resources/m0002-accounts-public-key-bindings.sql");
+    tx.batch_execute(query).await?;
+
+    // get the latest block in the db
+    let last_block_height = tx
+        .query_opt(
+            "SELECT summaries.height FROM summaries ORDER BY summaries.id DESC LIMIT 1",
+            &[],
+        )
+        .await?
+        .map(|row| row.try_get::<_, i64>(0))
+        .transpose()?
+        .map(|h| AbsoluteBlockHeight::from(h as u64))
+        .unwrap_or(0.into());
+
+    // create the client
+    let endpoint = endpoints.first().context(
+        "First node endpoint is not available. The indexer/migration file needs access to a node.",
+    )?;
+    let mut client = v2::Client::new(endpoint.clone()).await?;
+
+    // get all account infos
+    let accounts = client
+        .get_account_list(BlockIdentifier::AbsoluteHeight(last_block_height))
+        .await?
+        .response
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    // create variables for querying the node, concurrency limit and pending rows to be bulk inserted
+    let mut query_count = 0;
+    let accounts_length = accounts.len();
+    let batch_size = 1000;
+    let concurrent_query_limit = 50usize;
+    let mut pending_rows: Vec<PendingPublicKeyBindingInsertionRow> = Vec::with_capacity(batch_size);
+    let mut rows_inserted_count = 0;
+    println!(
+        "Details -- accounts to fetch and insert: {}, batch size: {}",
+        accounts_length, batch_size
+    );
+
+    // Create a buffer for querying the account info's - `concurrent_query_limit` defines how many are done in parallel with the node
+    let account_infos: Vec<AccountInfo> = stream::iter(accounts.into_iter())
+        .map(|account| {
+
+            let mut client = client.clone();
+            query_count += 1;
+
+            async move {
+                let account_info = client
+                    .get_account_info(&account.into(), last_block_height)
+                    .await
+                    .map(|resp| resp.response)
+                    .expect("Expected account info here");
+
+                println!(
+                    "account info query with node: {} out of: {}, account: {:?}",
+                    query_count, accounts_length, &account.0
+                );
+
+                account_info
+            }
+        })
+        .buffer_unordered(concurrent_query_limit)
+        .collect()
+        .await;
+
+    // For all our account info's we need to find the credentials and keys in the access structure and build them into a pending row to be inserted. Once we have reached the batch size for pending rows, they will get inserted together
+    for (index, account_info) in account_infos.into_iter().enumerate() {
+        let address: Vec<u8> = account_info.account_address.0.clone().to_vec();
+        let access_structure: AccountAccessStructure = (&account_info).into();
+        let is_simple_account = access_structure.num_keys() == 1;
+
+        for (cred_index, credential_keys) in access_structure.keys {
+            let credential_index: u8 = cred_index.into();
+            for (key_index, key) in credential_keys.keys {
+                let key_index: u8 = key_index.into();
+                let mut public_key = Vec::new();
+                key.serial(&mut public_key);
+
+                // create and push a pending row into the vector (later, they will be bulk inserted)
+                pending_rows.push((
+                    address.clone(),
+                    public_key.clone(),
+                    credential_index as i32,
+                    key_index as i32,
+                    is_simple_account,
+                ));
+            }
+        }
+
+        // Flush batch and write to the database once we have reached the batch size
+        if pending_rows.len() >= batch_size {
+            bulk_insert_pending_rows(tx, &pending_rows).await?;
+            rows_inserted_count += pending_rows.len();
+            println!("Bulk insert done now for account index: {} out of: {} accounts. Rows inserted so far: {}", index, accounts_length, rows_inserted_count);
+            pending_rows.clear();
+        }
+    }
+
+    // Flush any remaining pending rows to the DB (occurs when less than the batch limit was reached at the end)
+    if !pending_rows.is_empty() {
+        bulk_insert_pending_rows(tx, &pending_rows).await?;
+        println!("Finalized last bulk insert for {} rows", pending_rows.len());
+        pending_rows.clear();
+    }
+
+    println!("elasped time was: {:?}", start.elapsed());
+    Ok(())
+}
+
+/// helper function to bulk insert the pending rows to the DB
+pub async fn bulk_insert_pending_rows(
+    tx: &tokio_postgres::Transaction<'_>,
+    rows: &[PendingPublicKeyBindingInsertionRow],
+) -> Result<u64, tokio_postgres::Error> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut placeholders = Vec::with_capacity(rows.len());
+    let mut params: Vec<&(dyn ToSql + Sync)> = Vec::with_capacity(rows.len() * 5);
+
+    for (i, row) in rows.iter().enumerate() {
+        let base = i * 5;
+        placeholders.push(format!(
+            "(${}, ${}, ${}, ${}, ${})",
+            base + 1,
+            base + 2,
+            base + 3,
+            base + 4,
+            base + 5
+        ));
+
+        params.push(&row.0);
+        params.push(&row.1);
+        params.push(&row.2);
+        params.push(&row.3);
+        params.push(&row.4);
+    }
+
+    let sql = format!(
+        "INSERT INTO account_public_key_bindings \
+         (address, public_key, credential_index, key_index, is_simple_account) \
+         VALUES {}",
+        placeholders.join(", ")
+    );
+
+    tx.execute(sql.as_str(), &params).await
+}

--- a/src/migrations/m0002_acoount_public_key_binding.rs
+++ b/src/migrations/m0002_acoount_public_key_binding.rs
@@ -64,7 +64,6 @@ pub async fn run(tx: &mut Transaction<'_>, endpoints: &[v2::Endpoint]) -> anyhow
     // Create a buffer for querying the account info's - `concurrent_query_limit` defines how many are done in parallel with the node
     let account_infos: Vec<AccountInfo> = stream::iter(accounts.into_iter())
         .map(|account| {
-
             let mut client = client.clone();
             query_count += 1;
 


### PR DESCRIPTION
## Purpose

Adding a watcher that would track the key-update transactions and update the 

## Changes
- New type `PublicKeyBindingInfo`.
- Made `PublicKeyBindingInfo` as a part of `TransactionLogData`.
- `PreparedStatements` has two new fields of type `tokio_postgres::Statement`:
<t> `insert_key_bindings` and `delete_key_bindings`.
- DB task is extended to save public key to account address binding.
- Node task watches over `BlockItemSummaryDetails::AccountCreation`, `AccountTransactionEffects::CredentialKeysUpdated` and `AccountTransactionEffects::CredentialsUpdated` to monitor if changes in public key to account address bindings are needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
