### PR TITLE
Upward Unknown will be handled to raise an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## Unreleased changes
 
-- Handling Upward Known and Unknown usage from main fn get_cis2_events
-- Handling Upward Known and Unknown usage from BlockItemSummary fn affected_contracts
-- Handling Upward Known and Unknown usage from Client fn get_block_special_events
-- Added IndexingError type in lib
+- Update the Rust SDK for better forwards compatibility with future node versions and revised error handling or reporting for unknown transaction and event types. New type `IndexingError` created in lib. Error handling in fn `get_cis2_events`, `insert_transaction` and `on_finalized_block`.
 
 ## [0.14.0] - 2025-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Handling Upward Known and Unknown usage from main fn get_cis2_events
 - Handling Upward Known and Unknown usage from BlockItemSummary fn affected_contracts
 - Handling Upward Known and Unknown usage from Client fn get_block_special_events
+- Added IndexingError type in lib
 
 ## [0.14.0] - 2025-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased changes
 
-## [] - 2025-09-09
-
 - Added Upward usage in the transaction-logger service and throwing errors for unknown cases for affected_contracts
 
 ## [0.14.0] - 2025-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## [0.15.0] - 2025-09-09
+
+- Added Upward usage in the transaction-logger service and throwing errors for unknown
+
 ## [0.14.0] - 2025-08-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased changes
 
-## [0.15.0] - 2025-09-09
+## [] - 2025-09-09
 
-- Added Upward usage in the transaction-logger service and throwing errors for unknown
+- Added Upward usage in the transaction-logger service and throwing errors for unknown cases for affected_contracts
 
 ## [0.14.0] - 2025-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased changes
 
-- Added Upward usage in the transaction-logger service and throwing errors for unknown cases for affected_contracts
+- Handling Upward Known and Unknown usage from main fn get_cis2_events
+- Handling Upward Known and Unknown usage from BlockItemSummary fn affected_contracts
+- Handling Upward Known and Unknown usage from Client fn get_block_special_events
 
 ## [0.14.0] - 2025-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Update the Rust SDK for better forwards compatibility with future node versions and revised error handling or reporting for unknown transaction and event types. New type `IndexingError` created in lib. Error handling in fn `get_cis2_events`, `insert_transaction` and `on_finalized_block`.
+- Update the Rust SDK for better forwards compatibility with future node versions and revised error handling or reporting for unknown transaction and event types. If within the database hook callback has unknown data variants in the block processing, the process would complain and cease, raising `IndexingError` to alert.
 
 ## [0.14.0] - 2025-08-07
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,15 +204,9 @@ pub enum IndexingError {
     /// Database error.
     #[error("Error using the database {0}.")]
     PostgresError(#[from] postgres::Error),
-    /// Parsing errors.
-    #[error("Error happened parsing {0}.")]
-    ParsingError(String),
     /// Unknown type encountered error
-    #[error("Please update the rust SDK. Error could be due to {0}.")]
+    #[error("Please update the rust SDK. Reason for this could be due to {0}.")]
     Unknown(String),
-    /// Other errors while processing database data.
-    #[error("Error happened on database thread {0}.")]
-    OtherError(#[from] anyhow::Error),
 }
 
 /// Defines a set of necessary callbacks used while interacting with a node.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,11 @@ where
                     );
                 }
                 Err(e) => {
+                    if let IndexingError::UnknownData(reasons) = &e {
+                        log::error!("Encountered unknown data variant. Please update the rust SDK. Reason(s): {}", reasons);
+                        return Err(anyhow::anyhow!("Encountered unknown data variant. Please update the rust SDK. Reason(s): {}", reasons));
+                    }
+
                     successive_errors += 1;
                     // wait for 2^(min(successive_errors - 1, 7)) seconds before attempting.
                     // The reason for the min is that we bound the time between reconnects.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,9 +204,9 @@ pub enum IndexingError {
     /// Database error.
     #[error("Error using the database {0}.")]
     PostgresError(#[from] postgres::Error),
-    /// Unknown type encountered error
+    /// Unknown Data type encountered error
     #[error("Please update the rust SDK. Reason for this could be due to {0}.")]
-    Unknown(String),
+    UnknownData(String),
 }
 
 /// Defines a set of necessary callbacks used while interacting with a node.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ pub enum IndexingError {
     #[error("Error happened parsing {0}.")]
     ParsingError(String),
     /// Unknown type encountered error
-    #[error("Please update the rust SDK. Type {0} is unknown.")]
+    #[error("Please update the rust SDK. Error could be due to {0}.")]
     Unknown(String),
     /// Other errors while processing database data.
     #[error("Error happened on database thread {0}.")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,12 @@ impl PreparedStatements {
             tx.query_opt(&self.insert_ati, &values).await?;
         }
         // insert contracts
-        for affected in ts.summary.affected_contracts() {
+        let unwrapped_contracts = match ts.summary.affected_contracts() {
+            Upward::Known(contracts) => contracts,
+            Upward::Unknown => Vec::new(), // TODO: is this what we want to do for Unknown?
+        };
+        
+        for affected in unwrapped_contracts {
             let index = affected.index;
             let subindex = affected.subindex;
             let values = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ impl PreparedStatements {
             Upward::Known(contracts) => contracts,
             Upward::Unknown => {
                 return Err(IndexingError::Unknown(
-                    "Unknown upward encountered for affected contracts".to_string(),
+                    "Unknown upward error on ContractAddress".to_string(),
                 ));
             } // if Unknown, throw an error
         };
@@ -293,13 +293,13 @@ impl PreparedStatements {
         for upward_contract_address in upward_affected_contracts {
             let affected = upward_contract_address.known_or_else(|| {
                 log::error!(
-                    "Unknown affected contract in transaction summary {:?}",
+                    "Unknown upward error on ContractAddress {:?}",
                     ts.summary
                 );
                 IndexingError::Unknown(
-                    "Unknown affected contract in transaction summary".to_string(),
+                    "Unknown upward error on ContractAddress".to_string(),
                 )
-            })?; // `?` will propagate the DatabaseError if Unknown
+            })?; // encountered unknown contract_address, throw an error to prevent transaction insertion
 
             let index = affected.index;
             let subindex = affected.subindex;
@@ -656,7 +656,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
                             Ok(Some(special_transaction_outcome))
                         }
                         Upward::Unknown => Err(Status::unknown(
-                            "Unknown upward error on block_special_events",
+                            "Unknown upward error on SpecialTransactionOutcome",
                         )), // if unknown, throw an error also
                     }
                 }
@@ -669,7 +669,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
         let mut with_addresses = Vec::with_capacity(transaction_summaries.len());
         for summary in transaction_summaries {
             let affected_addresses = summary.affected_addresses().known_or_else(|| {
-                Status::unknown("Unknown upward encountered for affected addresses")
+                Status::unknown("Unknown upward error on AccountAddress")
             })?; // if unknown, throw Err Status::unknown
 
             let mut addresses = Vec::with_capacity(affected_addresses.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use concordium_rust_sdk::{
         hashes::BlockHash, queries::BlockInfo, AbsoluteBlockHeight, BlockItemSummary,
         ContractAddress, SpecialTransactionOutcome,
     },
-    v2::{self, FinalizedBlockInfo, Upward},
+    v2::{self, generated::address, FinalizedBlockInfo, Upward},
 };
 use futures::TryStreamExt;
 use std::{collections::HashSet, convert::TryFrom, hash::Hash};
@@ -617,7 +617,11 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
         // address
         let mut with_addresses = Vec::with_capacity(transaction_summaries.len());
         for summary in transaction_summaries {
-            let affected_addresses = summary.affected_addresses();
+            let affected_addresses = match summary.affected_addresses() {
+                Upward::Known(addresses) => addresses,
+                Upward::Unknown => Vec::new(), // TODO: is this what we want to do for Unknown?
+            };
+
             let mut addresses = Vec::with_capacity(affected_addresses.len());
             // resolve canonical addresses. This part is only needed because the index
             // is currently expected by "canonical address",

--- a/src/main.rs
+++ b/src/main.rs
@@ -536,7 +536,7 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Result<ContractEffects, IndexingErr
             }
             //if no events were parsed due to non cis2 logs, the vector will be empty
             //so just return the events vector, empty or not empty.
-            Ok(events)          
+            Ok(events)
         }
         None => {
             let init = match bi.contract_init() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,16 +644,14 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
             .get_block_special_events(finalized_block_info.height)
             .await?
             .response
-            .try_filter_map(|upward| {
-                async move {
-                    match upward {
-                        Upward::Known(special_transaction_outcome) => {
-                            Ok(Some(special_transaction_outcome))
-                        }
-                        Upward::Unknown => {
-                            Err(Status::unknown("Unknown SpecialTransactionOutcome type"))
-                        } // if unknown, throw an error also
+            .try_map(|upward| {                
+                match upward {
+                    Upward::Known(special_transaction_outcome) => {
+                        Ok(Some(special_transaction_outcome))
                     }
+                    Upward::Unknown => {
+                        Err(Status::unknown("Unknown SpecialTransactionOutcome type"))
+                    } // if unknown, throw an error also
                 }
             })
             .try_collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,11 +295,12 @@ impl PreparedStatements {
                 }
                 Upward::Unknown => {
                     //TODO: is this what we want to do for Unknown?
-                    println!("Unknown affected contract in transaction summary {:?}", ts.summary);
+                    println!(
+                        "Unknown affected contract in transaction summary {:?}",
+                        ts.summary
+                    );
                 }
             }
-            
-            
         }
 
         Ok(())
@@ -510,24 +511,23 @@ async fn get_last_block_height(
 /// The return value of [`None`] means there are no understandable CIS2 logs
 /// produced.
 fn get_cis2_events(bi: &BlockItemSummary) -> Option<Vec<(ContractAddress, Vec<cis2::Event>)>> {
-
     match bi.contract_update_logs() {
         Some(log_iter) => Some(
-        log_iter
-            .filter_map(|upward| match upward {
-                Upward::Known((ca, logs)) => {
-                    match logs
-                        .iter()
-                        .map(cis2::Event::try_from)
-                        .collect::<Result<Vec<_>, _>>()
-                    {
-                        Ok(ev) => Some((ca, ev)),
-                        Err(_) => None,
+            log_iter
+                .filter_map(|upward| match upward {
+                    Upward::Known((ca, logs)) => {
+                        match logs
+                            .iter()
+                            .map(cis2::Event::try_from)
+                            .collect::<Result<Vec<_>, _>>()
+                        {
+                            Ok(ev) => Some((ca, ev)),
+                            Err(_) => None,
+                        }
                     }
-                }
-                Upward::Unknown => None,  // TODO: is this what we want to do for Unknown?
-            })
-            .collect()
+                    Upward::Unknown => None, // TODO: is this what we want to do for Unknown?
+                })
+                .collect(),
         ),
         None => {
             let init = bi.contract_init()?;
@@ -628,7 +628,9 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
             .try_filter_map(|upward| {
                 async move {
                     match upward {
-                        Upward::Known(special_transaction_outcome) => Ok(Some(special_transaction_outcome)),
+                        Upward::Known(special_transaction_outcome) => {
+                            Ok(Some(special_transaction_outcome))
+                        }
                         Upward::Unknown => Ok(None), // TODO: is this what we want to do for Unknown?
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,7 @@ impl PreparedStatements {
             let affected = contract_address.known_or_else(|| {
                 log::error!("Could not determine affected contracts of an unknown type of AccountTransactionEffects. {:?}", ts.summary);
                 IndexingError::UnknownData("Could not determine affected contracts of an unknown type of AccountTransactionEffects.".to_string())
-            })?; // encountered unknown contract_address, throw an error to prevent transaction insertion
+            })?; // encountered unknown contract_address, throw an error, this will stop the insert into db process and alert the user to update the rust SDK
 
             let index = affected.index;
             let subindex = affected.subindex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,7 @@ impl PreparedStatements {
         // insert contracts
         let unwrapped_upwards = match ts.summary.affected_contracts() {
             Upward::Known(contracts) => contracts,
-            Upward::Unknown => Vec::new(), // TODO: is this what we want to do for Unknown?
+            Upward::Unknown => Vec::new(), // if Unknown, pass an empty vec, no contracts to insert
         };
 
         for upward in unwrapped_upwards {
@@ -294,8 +294,8 @@ impl PreparedStatements {
                     tx.query_opt(&self.insert_cti, &values).await?;
                 }
                 Upward::Unknown => {
-                    //TODO: is this what we want to do for Unknown?
-                    println!(
+                    //if unknown, we don't do anything, just log it
+                    log::info!(
                         "Unknown affected contract in transaction summary {:?}",
                         ts.summary
                     );
@@ -525,7 +525,7 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Option<Vec<(ContractAddress, Vec<ci
                             Err(_) => None,
                         }
                     }
-                    Upward::Unknown => None, // TODO: is this what we want to do for Unknown?
+                    Upward::Unknown => None, //returning None, keeping it same result as Err, no understantable CIS2 logs
                 })
                 .collect(),
         ),
@@ -631,7 +631,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
                         Upward::Known(special_transaction_outcome) => {
                             Ok(Some(special_transaction_outcome))
                         }
-                        Upward::Unknown => Ok(None), // TODO: is this what we want to do for Unknown?
+                        Upward::Unknown => Ok(None), // we ignore unknown special events
                     }
                 }
             })
@@ -644,7 +644,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
         for summary in transaction_summaries {
             let affected_addresses = match summary.affected_addresses() {
                 Upward::Known(addresses) => addresses,
-                Upward::Unknown => Vec::new(), // TODO: is this what we want to do for Unknown?
+                Upward::Unknown => Vec::new(), // returning empty vec if unknown
             };
 
             let mut addresses = Vec::with_capacity(affected_addresses.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,13 +292,8 @@ impl PreparedStatements {
 
         for upward_contract_address in upward_affected_contracts {
             let affected = upward_contract_address.known_or_else(|| {
-                log::error!(
-                    "Unknown upward error on ContractAddress {:?}",
-                    ts.summary
-                );
-                IndexingError::Unknown(
-                    "Unknown upward error on ContractAddress".to_string(),
-                )
+                log::error!("Unknown upward error on ContractAddress {:?}", ts.summary);
+                IndexingError::Unknown("Unknown upward error on ContractAddress".to_string())
             })?; // encountered unknown contract_address, throw an error to prevent transaction insertion
 
             let index = affected.index;
@@ -668,9 +663,9 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
         // address
         let mut with_addresses = Vec::with_capacity(transaction_summaries.len());
         for summary in transaction_summaries {
-            let affected_addresses = summary.affected_addresses().known_or_else(|| {
-                Status::unknown("Unknown upward error on AccountAddress")
-            })?; // if unknown, throw Err Status::unknown
+            let affected_addresses = summary
+                .affected_addresses()
+                .known_or_else(|| Status::unknown("Unknown upward error on AccountAddress"))?; // if unknown, throw Err Status::unknown
 
             let mut addresses = Vec::with_capacity(affected_addresses.len());
             // resolve canonical addresses. This part is only needed because the index

--- a/src/main.rs
+++ b/src/main.rs
@@ -625,6 +625,14 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
             .get_block_special_events(finalized_block_info.height)
             .await?
             .response
+            .try_filter_map(|upward| {
+                async move {
+                    match upward {
+                        Upward::Known(special_transaction_outcome) => Ok(Some(special_transaction_outcome)),
+                        Upward::Unknown => Ok(None), // TODO: is this what we want to do for Unknown?
+                    }
+                }
+            })
             .try_collect()
             .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,13 +281,13 @@ impl PreparedStatements {
             tx.query_opt(&self.insert_ati, &values).await?;
         }
         // insert contracts
-        let unwrapped_upwards = match ts.summary.affected_contracts() {
+        let upward_affected_contracts = match ts.summary.affected_contracts() {
             Upward::Known(contracts) => contracts,
             Upward::Unknown => Vec::new(), // if Unknown, pass an empty vec, no contracts to insert
         };
 
-        for upward in unwrapped_upwards {
-            match upward {
+        for upward_contract_address in upward_affected_contracts {
+            match upward_contract_address {
                 Upward::Known(affected) => {
                     let index = affected.index;
                     let subindex = affected.subindex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,15 +518,15 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Result<ContractEffects, IndexingErr
             for contract_log in log_iter {
                 match contract_log {
                     Upward::Known((ca, logs)) => {
-
                         let evs: Option<ContractEvents> = match logs
-                            .iter().map(cis2::Event::try_from)
-                            .collect::<Result<Vec<cis2::Event>, _>>() 
+                            .iter()
+                            .map(cis2::Event::try_from)
+                            .collect::<Result<Vec<cis2::Event>, _>>()
                         {
                             Ok(events) => Some(events),
                             Err(_) => None,
-                        }; 
-                        
+                        };
+
                         if let Some(evs) = evs {
                             events.push((ca, evs));
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -544,7 +544,7 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Result<Option<ContractEffects>, Dat
         None => {
             let init = bi
                 .contract_init()
-                .ok_or(DatabaseError::OtherError(anyhow!("")))?;
+                .ok_or(DatabaseError::OtherError(anyhow!("Contract init failed")))?;
 
             let cis2: Vec<_> = init
                 .events

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,7 +644,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
             .get_block_special_events(finalized_block_info.height)
             .await?
             .response
-            .try_map(|upward| {                
+            .try_map(|upward| {
                 match upward {
                     Upward::Known(special_transaction_outcome) => {
                         Ok(Some(special_transaction_outcome))

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use concordium_rust_sdk::{
         hashes::BlockHash, queries::BlockInfo, AbsoluteBlockHeight, BlockItemSummary,
         ContractAddress, SpecialTransactionOutcome,
     },
-    v2::{self, generated::address, FinalizedBlockInfo, Upward},
+    v2::{self, FinalizedBlockInfo, Upward},
 };
 use futures::TryStreamExt;
 use std::{collections::HashSet, convert::TryFrom, hash::Hash};

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,8 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Result<ContractEffects, IndexingErr
                         let evs: Option<ContractEvents> = logs
                             .iter()
                             .map(cis2::Event::try_from)
-                            .collect::<Result<Vec<cis2::Event>, _>>().ok();
+                            .collect::<Result<Vec<cis2::Event>, _>>()
+                            .ok();
 
                         if let Some(evs) = evs {
                             events.push((ca, evs));

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,14 +518,10 @@ fn get_cis2_events(bi: &BlockItemSummary) -> Result<ContractEffects, IndexingErr
             for contract_log in log_iter {
                 match contract_log {
                     Upward::Known((ca, logs)) => {
-                        let evs: Option<ContractEvents> = match logs
+                        let evs: Option<ContractEvents> = logs
                             .iter()
                             .map(cis2::Event::try_from)
-                            .collect::<Result<Vec<cis2::Event>, _>>()
-                        {
-                            Ok(events) => Some(events),
-                            Err(_) => None,
-                        };
+                            .collect::<Result<Vec<cis2::Event>, _>>().ok();
 
                         if let Some(evs) = evs {
                             events.push((ca, evs));

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,14 +644,16 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
             .get_block_special_events(finalized_block_info.height)
             .await?
             .response
-            .try_map(|upward| {
-                match upward {
-                    Upward::Known(special_transaction_outcome) => {
-                        Ok(Some(special_transaction_outcome))
+            .try_filter_map(|upward| {
+                async move {
+                    match upward {
+                        Upward::Known(special_transaction_outcome) => {
+                            Ok(Some(special_transaction_outcome))
+                        }
+                        Upward::Unknown => {
+                            Err(Status::unknown("Unknown SpecialTransactionOutcome type"))
+                        } // if unknown, throw an error also
                     }
-                    Upward::Unknown => {
-                        Err(Status::unknown("Unknown SpecialTransactionOutcome type"))
-                    } // if unknown, throw an error also
                 }
             })
             .try_collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,13 +281,13 @@ impl PreparedStatements {
         }
 
         // insert contracts
-        let upward_affected_contracts = ts.summary.affected_contracts().known_or_else(|| {
+        let affected_contracts = ts.summary.affected_contracts().known_or_else(|| {
             log::error!("Could not determine affected contracts for a BlockItemSummary of unknown type. {:?}", ts.summary);
             IndexingError::UnknownData("Could not determine affected contracts for a BlockItemSummary of unknown type.".to_string())
         })?; // if Unknown, throw an error
 
-        for upward_contract_address in upward_affected_contracts {
-            let affected = upward_contract_address.known_or_else(|| {
+        for contract_address in affected_contracts {
+            let affected = contract_address.known_or_else(|| {
                 log::error!("Could not determine affected contracts of an unknown type of AccountTransactionEffects. {:?}", ts.summary);
                 IndexingError::UnknownData("Could not determine affected contracts of an unknown type of AccountTransactionEffects.".to_string())
             })?; // encountered unknown contract_address, throw an error to prevent transaction insertion

--- a/src/main.rs
+++ b/src/main.rs
@@ -640,6 +640,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
                 .try_collect()
                 .await?
         };
+
         let special_events = node
             .get_block_special_events(finalized_block_info.height)
             .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,7 +655,7 @@ impl NodeHooks<TransactionLogData> for CanonicalAddressCache {
                         Upward::Known(special_transaction_outcome) => {
                             Ok(Some(special_transaction_outcome))
                         }
-                        Upward::Unknown => Err(Status::unknown(                            
+                        Upward::Unknown => Err(Status::unknown(
                             "Unknown upward error on block_special_events",
                         )), // if unknown, throw an error also
                     }


### PR DESCRIPTION
Jira-Id: COR-1780

## Purpose

Enabling forward compatibility in transaction-logger with the recent changes on rust SDK

## Changes

Ensuring function calls are handling Upward and if Upward.Unknown is encountered, an error will be raised. The insert_db overall would see this error and complain.
Have introduced also IndexingError, to wrap the different error types currently used within here, so that we could return at the higher level of the call. Using DatabaseError.Other does not appear to fit or could lead to inaccurate error display.

## Checklist

- [ X ] My code follows the style of this project.
- [ X ] The code compiles without warnings.
- [ X ] I have performed a self-review of the changes.
- [ X ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ X ] (If necessary) I have updated the CHANGELOG.


