### PR TITLE
Account Address to Public Key binding watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased changes
 
+- Added `PublicKeyBindingInfo` type that represents public key info of accounts access structure.
+- Added `PublicKeyBindingInfo` into `TransactionLogData`.
+- Added `insert_key_bindings` and `delete_key_bindings` feilds into `PreparedStatements`.
+- The DB task is extended to save account's address and public key binding.
+- The Node task is extended to monitor for public key update and new account creation transactions.
+
 ## [0.14.0] - 2025-08-07
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,7 +516,7 @@ impl PreparedStatements {
         tx: &DBTransaction<'_>,
         address: &[u8],
     ) -> Result<(), postgres::Error> {
-        tx.execute(&self.delete_key_bindings, &[&&address[..]])
+        tx.execute(&self.delete_key_bindings, &[&address])
             .await?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,8 +516,7 @@ impl PreparedStatements {
         tx: &DBTransaction<'_>,
         address: &[u8],
     ) -> Result<(), postgres::Error> {
-        tx.execute(&self.delete_key_bindings, &[&address])
-            .await?;
+        tx.execute(&self.delete_key_bindings, &[&address]).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Purpose

Adding a watcher for transactions in the block that create new account/update keys and credntials of an account.

## Changes

- Added `PublicKeyBindingInfo` type that represents public key info of accounts access structure.
- Added `PublicKeyBindingInfo` into `TransactionLogData`.
- Added `insert_key_bindings` and `delete_key_bindings` feilds into `PreparedStatements`.
- The DB task is extended to save account's address and public key binding.
- The Node task is extended to monitor for public key update and new account creation transactions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
